### PR TITLE
Fix Startup Error

### DIFF
--- a/sample/MauiModule/Views/ViewA.xaml
+++ b/sample/MauiModule/Views/ViewA.xaml
@@ -4,9 +4,9 @@
              x:Class="MauiModule.Views.ViewA"
              Title="{Binding Title}"
              BackgroundColor="White">
-  <StackLayout>
-    <Label Text="Welcome to .NET MAUI!"
-            VerticalOptions="CenterAndExpand" 
-            HorizontalOptions="CenterAndExpand" />
+  <StackLayout VerticalOptions="CenterAndExpand"
+               HorizontalOptions="CenterAndExpand">
+    <Label Text="View A" HorizontalTextAlignment="Center" />
+    <Label Text="Welcome to Prism for .NET MAUI!" HorizontalTextAlignment="Center" />
   </StackLayout>
 </ContentPage>

--- a/sample/MauiModule/Views/ViewB.xaml
+++ b/sample/MauiModule/Views/ViewB.xaml
@@ -4,9 +4,9 @@
              x:Class="MauiModule.Views.ViewB"
              Title="{Binding Title}"
              BackgroundColor="White">
-  <StackLayout>
-    <Label Text="Welcome to .NET MAUI!"
-            VerticalOptions="CenterAndExpand" 
-            HorizontalOptions="CenterAndExpand" />
+  <StackLayout VerticalOptions="CenterAndExpand"
+               HorizontalOptions="CenterAndExpand">
+    <Label Text="View B" HorizontalTextAlignment="Center" />
+    <Label Text="Welcome to Prism for .NET MAUI!" HorizontalTextAlignment="Center" />
   </StackLayout>
 </ContentPage>

--- a/sample/MauiModule/Views/ViewC.xaml
+++ b/sample/MauiModule/Views/ViewC.xaml
@@ -4,9 +4,9 @@
              x:Class="MauiModule.Views.ViewC"
              Title="{Binding Title}"
              BackgroundColor="White">
-  <StackLayout>
-    <Label Text="Welcome to .NET MAUI!"
-            VerticalOptions="CenterAndExpand" 
-            HorizontalOptions="CenterAndExpand" />
+  <StackLayout VerticalOptions="CenterAndExpand"
+               HorizontalOptions="CenterAndExpand">
+    <Label Text="View C" HorizontalTextAlignment="Center" />
+    <Label Text="Welcome to Prism for .NET MAUI!" HorizontalTextAlignment="Center" />
   </StackLayout>
 </ContentPage>

--- a/sample/MauiModule/Views/ViewD.xaml
+++ b/sample/MauiModule/Views/ViewD.xaml
@@ -4,9 +4,9 @@
              x:Class="MauiModule.Views.ViewD"
              Title="{Binding Title}"
              BackgroundColor="White">
-  <StackLayout>
-    <Label Text="Welcome to .NET MAUI!"
-            VerticalOptions="CenterAndExpand" 
-            HorizontalOptions="CenterAndExpand" />
+  <StackLayout VerticalOptions="CenterAndExpand"
+               HorizontalOptions="CenterAndExpand">
+    <Label Text="View D" HorizontalTextAlignment="Center" />
+    <Label Text="Welcome to Prism for .NET MAUI!" HorizontalTextAlignment="Center" />
   </StackLayout>
 </ContentPage>

--- a/sample/PrismMauiDemo/App.xaml.cs
+++ b/sample/PrismMauiDemo/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Prism;
+using Prism;
 using Prism.Navigation;
 
 namespace PrismMauiDemo;
@@ -12,7 +12,7 @@ public partial class App : PrismApplication
 
     protected override async Task OnWindowCreated(IActivationState activationState)
     {
-        var result = await NavigationService.NavigateAsync("MainPage/NavigationPage/SamplePage");
+        var result = await NavigationService.NavigateAsync("MainPage/NavigationPage/ViewA");
         if (!result.Success)
         {
             System.Diagnostics.Debugger.Break();

--- a/sample/PrismMauiDemo/Views/MainPage.xaml
+++ b/sample/PrismMauiDemo/Views/MainPage.xaml
@@ -6,7 +6,7 @@
              Title="MainPage"
              BackgroundColor="White">
   <FlyoutPage.Flyout>
-    <ContentPage>
+    <ContentPage Title="Menu">
       <StackLayout Margin="20">
         <Button Text="ViewA"
                 Command="{Binding NavigateCommand}"

--- a/src/Prism.DryIoc.Maui/DryIocContainerExtension.cs
+++ b/src/Prism.DryIoc.Maui/DryIocContainerExtension.cs
@@ -1,20 +1,56 @@
 ﻿using System;
-using DryIoc.Microsoft.DependencyInjection;
+using DryIoc;
 using Microsoft.Extensions.DependencyInjection;
 using Prism.Ioc;
 
-namespace Prism.DryIoc
-{
-    partial class DryIocContainerExtension : IServiceCollectionAware
-    {
-        public IServiceProvider CreateServiceProvider()
-        {
-            return Instance.BuildServiceProvider();
-        }
+namespace Prism.DryIoc;
 
-        public void Populate(IServiceCollection services)
+partial class DryIocContainerExtension : IServiceCollectionAware
+{
+    public IServiceProvider CreateServiceProvider()
+    {
+        var capabilities = new DryIocServiceProviderCapabilities(Instance);
+        var singletons = Instance.SingletonScope;
+        singletons.Use<IServiceProviderIsService>(capabilities);
+        singletons.Use<ISupportRequiredService>(capabilities);
+        singletons.UseFactory<IServiceScopeFactory>(r => new DryIocServiceScopeFactory(r));
+
+        return Instance;
+    }
+
+    public void Populate(IServiceCollection services)
+    {
+        foreach (var descriptor in services)
+            RegisterDescriptor(Instance, descriptor);
+
+        var errors = Instance.Validate();
+    }
+
+    static IReuse ToReuse(ServiceLifetime lifetime) =>
+        lifetime == ServiceLifetime.Singleton ? Reuse.Singleton :
+        lifetime == ServiceLifetime.Scoped ? Reuse.ScopedOrSingleton : // see, that we have Reuse.ScopedOrSingleton here instead of Reuse.Scoped
+        Reuse.Transient;
+
+    static void RegisterDescriptor(IContainer container, ServiceDescriptor descriptor)
+    {
+        var serviceType = descriptor.ServiceType;
+        var implType = descriptor.ImplementationType;
+        if (implType != null)
         {
-            Instance.Populate(services);
+            container.Register(ReflectionFactory.Of(implType, ToReuse(descriptor.Lifetime)), serviceType,
+                null, null, isStaticallyChecked: implType == serviceType);
+        }
+        else if (descriptor.ImplementationFactory != null)
+        {
+            container.Register(DelegateFactory.Of(descriptor.ImplementationFactory.ToFactoryDelegate, ToReuse(descriptor.Lifetime)), serviceType,
+                null, null, isStaticallyChecked: true);
+        }
+        else
+        {
+            var instance = descriptor.ImplementationInstance;
+            container.Register(InstanceFactory.Of(instance), serviceType,
+                null, null, isStaticallyChecked: true);
+            container.TrackDisposable(instance);
         }
     }
 }

--- a/src/Prism.DryIoc.Maui/DryIocServiceProviderCapabilities.cs
+++ b/src/Prism.DryIoc.Maui/DryIocServiceProviderCapabilities.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using DryIoc;
+using Microsoft.Extensions.DependencyInjection;
+using Prism.Ioc;
+
+namespace Prism.DryIoc;
+
+internal sealed class DryIocServiceProviderCapabilities : IServiceProviderIsService, ISupportRequiredService
+{
+    private readonly IContainer _container;
+    /// <summary>Statefully wraps the passed <paramref name="container"/></summary>
+    public DryIocServiceProviderCapabilities(IContainer container) => _container = container;
+
+    /// <inheritdoc />
+    public bool IsService(Type serviceType)
+    {
+        // I am not fully comprehend but MS.DI considers asking for the open-generic type even if it is registered to return `false`
+        // Probably mixing here the fact that open type cannot be instantiated without providing the concrete type argument.
+        // But I think it is conflating two things and making the reasoning harder.
+        if (serviceType.IsGenericTypeDefinition)
+            return false;
+
+        if (serviceType == typeof(IServiceProviderIsService) ||
+            serviceType == typeof(ISupportRequiredService) ||
+            serviceType == typeof(IServiceScopeFactory))
+            return true;
+
+        if (_container.IsRegistered(serviceType))
+            return true;
+
+        if (serviceType.IsGenericType &&
+            _container.IsRegistered(serviceType.GetGenericTypeDefinition()))
+            return true;
+
+        return _container.IsRegistered(serviceType, factoryType: FactoryType.Wrapper);
+    }
+
+    /// <inheritdoc />
+    public object GetRequiredService(Type serviceType) => _container.Resolve(serviceType);
+}

--- a/src/Prism.DryIoc.Maui/DryIocServiceScope.cs
+++ b/src/Prism.DryIoc.Maui/DryIocServiceScope.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using DryIoc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Prism.DryIoc;
+
+internal sealed class DryIocServiceScope : IServiceScope
+{
+    /// <inheritdoc />
+    public IServiceProvider ServiceProvider => _resolverContext;
+    private readonly IResolverContext _resolverContext;
+
+    /// <summary>Creating from resolver context</summary>
+    public DryIocServiceScope(IResolverContext resolverContext) => _resolverContext = resolverContext;
+
+    /// <summary>Disposes the underlying resolver context</summary>
+    public void Dispose() => _resolverContext.Dispose();
+}

--- a/src/Prism.DryIoc.Maui/DryIocServiceScopeFactory.cs
+++ b/src/Prism.DryIoc.Maui/DryIocServiceScopeFactory.cs
@@ -1,0 +1,24 @@
+﻿using DryIoc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Prism.DryIoc;
+
+internal sealed class DryIocServiceScopeFactory : IServiceScopeFactory
+{
+    private readonly IResolverContext _scopedResolver;
+
+    /// <summary>Stores passed scoped container to open nested scope.</summary>
+    /// <param name="scopedResolver">Scoped container to be used to create nested scope.</param>
+    public DryIocServiceScopeFactory(IResolverContext scopedResolver) => _scopedResolver = scopedResolver;
+
+    /// <summary>Opens scope and wraps it into DI <see cref="IServiceScope"/> interface.</summary>
+    /// <returns>DI wrapper of opened scope.</returns>
+    public IServiceScope CreateScope()
+    {
+        var r = _scopedResolver;
+        var scope = r.ScopeContext == null
+            ? Scope.Of(r.OwnCurrentScope)
+            : r.ScopeContext.SetCurrent(p => Scope.Of(p));
+        return new DryIocServiceScope(r.WithCurrentScope(scope));
+    }
+}

--- a/src/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
+++ b/src/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.0.1" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Prism.DryIoc.Maui/PrismAppExtensions.cs
+++ b/src/Prism.DryIoc.Maui/PrismAppExtensions.cs
@@ -3,29 +3,25 @@ using Microsoft.Maui.Hosting;
 using Prism;
 using Prism.DryIoc;
 
-namespace Microsoft.Maui
+namespace Microsoft.Maui;
+
+/// <summary>
+/// Application base class using DryIoc
+/// </summary>
+public static class PrismAppExtensions
 {
-    /// <summary>
-    /// Application base class using DryIoc
-    /// </summary>
-    public static class PrismAppExtensions
+    public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder)
+        where TApp : PrismApplication
     {
-        public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder)
-            where TApp : PrismApplication
-        {
-            return builder.UsePrismApp<TApp>(new DryIocContainerExtension());
-        }
+        return builder.UsePrismApp<TApp>(new DryIocContainerExtension());
+    }
 
-        public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, Rules rules)
-            where TApp : PrismApplication
-        {
-            return builder.UsePrismApp<TApp>(new DryIocContainerExtension(rules));
-        }
-
-        public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, global::DryIoc.IContainer container)
-            where TApp : PrismApplication
-        {
-            return builder.UsePrismApp<TApp>(new DryIocContainerExtension(container));
-        }
+    public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, Rules rules)
+        where TApp : PrismApplication
+    {
+        rules = rules.WithTrackingDisposableTransients()
+            .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
+            .WithFactorySelector(Rules.SelectLastRegisteredFactory());
+        return builder.UsePrismApp<TApp>(new DryIocContainerExtension(rules));
     }
 }

--- a/src/Prism.Maui/Ioc/PrismServiceProviderFactory.cs
+++ b/src/Prism.Maui/Ioc/PrismServiceProviderFactory.cs
@@ -1,45 +1,25 @@
-using Microsoft.Extensions.DependencyInjection;
+namespace Prism.Ioc;
 
-namespace Prism.Ioc
+public class PrismServiceProviderFactory : IServiceProviderFactory<IContainerExtension>
 {
-    public class PrismServiceProviderFactory : IServiceProviderFactory<IContainerExtension>
+    private Action<IContainerExtension> _registerTypes { get; }
+
+    public PrismServiceProviderFactory(Action<IContainerExtension> registerTypes)
     {
-        private Action<IContainerExtension> _registerTypes { get; }
-
-        public PrismServiceProviderFactory(Action<IContainerExtension> registerTypes)
-        {
-            _registerTypes = registerTypes;
-        }
-
-        public IContainerExtension CreateBuilder(IServiceCollection services)
-        {
-            var container = ContainerLocator.Current;
-            container.Populate(services);
-            _registerTypes(container);
-            if (!container.IsRegistered(typeof(IServiceScopeFactory)))
-                container.Register<IServiceScopeFactory, ServiceScopeFactory>();
-
-            return container;
-        }
-
-        public IServiceProvider CreateServiceProvider(IContainerExtension containerExtension)
-        {
-            return containerExtension.CreateServiceProvider();
-        }
+        _registerTypes = registerTypes;
     }
 
-    internal class ServiceScopeFactory : IServiceScopeFactory
+    public IContainerExtension CreateBuilder(IServiceCollection services)
     {
-        private IServiceProvider _services { get; }
+        var container = ContainerLocator.Current;
+        container.Populate(services);
+        _registerTypes(container);
 
-        public ServiceScopeFactory(IServiceProvider services)
-        {
-            _services = services;
-        }
+        return container;
+    }
 
-        public IServiceScope CreateScope()
-        {
-            return _services.CreateScope();
-        }
+    public IServiceProvider CreateServiceProvider(IContainerExtension containerExtension)
+    {
+        return containerExtension.CreateServiceProvider();
     }
 }

--- a/src/Prism.Maui/Mvvm/ViewModelLocationProvider2.cs
+++ b/src/Prism.Maui/Mvvm/ViewModelLocationProvider2.cs
@@ -1,0 +1,148 @@
+﻿using System.Globalization;
+using System.Reflection;
+
+namespace Prism.Mvvm;
+
+/// <summary>
+/// The ViewModelLocationProvider2 class locates the view model for the view that has the AutoWireViewModelChanged attached property set to true.
+/// The view model will be located and injected into the view's DataContext. To locate the view model, two strategies are used: First the ViewModelLocationProvider2
+/// will look to see if there is a view model factory registered for that view, if not it will try to infer the view model using a convention based approach.
+/// This class also provides methods for registering the view model factories,
+/// and also to override the default view model factory and the default view type to view model type resolver.
+/// </summary>
+public static class ViewModelLocationProvider2
+{
+    ///// <summary>
+    ///// A dictionary that contains all the registered factories for the views.
+    ///// </summary>
+    //static Dictionary<string, Func<object>> _factories = new Dictionary<string, Func<object>>();
+
+    /// <summary>
+    /// A dictionary that contains all the registered ViewModel types for the views.
+    /// </summary>
+    static Dictionary<string, Type> _typeFactories = new Dictionary<string, Type>();
+
+    /// <summary>
+    /// The default view model factory which provides the ViewModel type as a parameter.
+    /// </summary>
+    static Func<Type, object> _defaultViewModelFactory = type => Activator.CreateInstance(type);
+
+    /// <summary>
+    /// ViewModelFactory that provides the View instance and ViewModel type as parameters.
+    /// </summary>
+    static Func<object, Type, object> _defaultViewModelFactoryWithViewParameter;
+
+    /// <summary>
+    /// Default view type to view model type resolver, assumes the view model is in same assembly as the view type, but in the "ViewModels" namespace.
+    /// </summary>
+    static Func<Type, Type> _defaultViewTypeToViewModelTypeResolver =
+        viewType =>
+        {
+            var viewName = viewType.FullName;
+            viewName = viewName.Replace(".Views.", ".ViewModels.");
+            var viewAssemblyName = viewType.GetTypeInfo().Assembly.FullName;
+            var suffix = viewName.EndsWith("View") ? "Model" : "ViewModel";
+            var viewModelName = String.Format(CultureInfo.InvariantCulture, "{0}{1}, {2}", viewName, suffix, viewAssemblyName);
+            return Type.GetType(viewModelName);
+        };
+
+    static Func<object, Type> _defaultViewToViewModelTypeResolver = view => null;
+
+    /// <summary>
+    /// Sets the default view model factory.
+    /// </summary>
+    /// <param name="viewModelFactory">The view model factory which provides the ViewModel type as a parameter.</param>
+    public static void SetDefaultViewModelFactory(Func<Type, object> viewModelFactory)
+    {
+        _defaultViewModelFactory = viewModelFactory;
+    }
+
+    /// <summary>
+    /// Sets the default view model factory.
+    /// </summary>
+    /// <param name="viewModelFactory">The view model factory that provides the View instance and ViewModel type as parameters.</param>
+    public static void SetDefaultViewModelFactory(Func<object, Type, object> viewModelFactory)
+    {
+        _defaultViewModelFactoryWithViewParameter = viewModelFactory;
+    }
+
+    /// <summary>
+    /// Sets the default view type to view model type resolver.
+    /// </summary>
+    /// <param name="viewTypeToViewModelTypeResolver">The view type to view model type resolver.</param>
+    public static void SetDefaultViewTypeToViewModelTypeResolver(Func<Type, Type> viewTypeToViewModelTypeResolver)
+    {
+        _defaultViewTypeToViewModelTypeResolver = viewTypeToViewModelTypeResolver;
+    }
+
+    public static void SetDefaultViewToViewModelTypeResolver(Func<object, Type> viewToViewModelTypeResolver) =>
+        _defaultViewToViewModelTypeResolver = viewToViewModelTypeResolver;
+
+    /// <summary>
+    /// Automatically looks up the viewmodel that corresponds to the current view, using two strategies:
+    /// It first looks to see if there is a mapping registered for that view, if not it will fallback to the convention based approach.
+    /// </summary>
+    /// <param name="view">The dependency object, typically a view.</param>
+    /// <param name="setDataContextCallback">The call back to use to create the binding between the View and ViewModel</param>
+    public static void AutoWireViewModelChanged(object view, Action<object, object> setDataContextCallback)
+    {
+        // Try mappings first
+        object viewModel = null;
+
+        var viewModelType = _defaultViewToViewModelTypeResolver(view);
+
+        //check type mappings
+        if (viewModelType == null)
+            viewModelType = GetViewModelTypeForView(view.GetType());
+
+        // fallback to convention based
+        if (viewModelType == null)
+            viewModelType = _defaultViewTypeToViewModelTypeResolver(view.GetType());
+
+        if (viewModelType == null)
+            return;
+
+        viewModel = _defaultViewModelFactoryWithViewParameter != null ? _defaultViewModelFactoryWithViewParameter(view, viewModelType) : _defaultViewModelFactory(viewModelType);
+
+
+        setDataContextCallback(view, viewModel);
+    }
+
+    /// <summary>
+    /// Gets the ViewModel type for the specified view.
+    /// </summary>
+    /// <param name="view">The View that the ViewModel wants.</param>
+    /// <returns>The ViewModel type that corresponds to the View.</returns>
+    private static Type GetViewModelTypeForView(Type view)
+    {
+        var viewKey = view.ToString();
+
+        if (_typeFactories.ContainsKey(viewKey))
+            return _typeFactories[viewKey];
+
+        return null;
+    }
+
+    /// <summary>
+    /// Registers a ViewModel type for the specified view type.
+    /// </summary>
+    /// <typeparam name="T">The View</typeparam>
+    /// <typeparam name="VM">The ViewModel</typeparam>
+    public static void Register<T, VM>()
+    {
+        var viewType = typeof(T);
+        var viewModelType = typeof(VM);
+
+        Register(viewType.ToString(), viewModelType);
+    }
+
+    /// <summary>
+    /// Registers a ViewModel type for the specified view.
+    /// </summary>
+    /// <param name="viewTypeName">The View type name</param>
+    /// <param name="viewModelType">The ViewModel type</param>
+    public static void Register(string viewTypeName, Type viewModelType)
+    {
+        _typeFactories[viewTypeName] = viewModelType;
+    }
+}

--- a/src/Prism.Maui/Mvvm/ViewModelLocator.cs
+++ b/src/Prism.Maui/Mvvm/ViewModelLocator.cs
@@ -1,54 +1,70 @@
-﻿using Microsoft.Maui.Controls;
+﻿namespace Prism.Mvvm;
 
-namespace Prism.Mvvm
+/// <summary>
+/// This class defines the attached property and related change handler that calls the <see cref="Prism.Mvvm.ViewModelLocationProvider2"/>.
+/// </summary>
+public static class ViewModelLocator
 {
     /// <summary>
-    /// This class defines the attached property and related change handler that calls the <see cref="Prism.Mvvm.ViewModelLocationProvider"/>.
+    /// Instructs Prism whether or not to automatically create an instance of a ViewModel using a convention, and assign the associated View's <see cref="BindableObject.BindingContext"/> to that instance.
     /// </summary>
-    public static class ViewModelLocator
+    public static readonly BindableProperty AutowireViewModelProperty =
+        BindableProperty.CreateAttached("AutowireViewModel", typeof(bool?), typeof(ViewModelLocator), null, propertyChanged: OnAutowireViewModelChanged);
+
+    internal static readonly BindableProperty ViewModelProperty =
+        BindableProperty.CreateAttached("ViewModelType",
+            typeof(Type),
+            typeof(ViewModelLocator),
+            null,
+            propertyChanged: OnViewModelPropertyChanged);
+
+    /// <summary>
+    /// Gets the AutowireViewModel property value.
+    /// </summary>
+    /// <param name="bindable"></param>
+    /// <returns></returns>
+    public static bool? GetAutowireViewModel(BindableObject bindable)
     {
-        /// <summary>
-        /// Instructs Prism whether or not to automatically create an instance of a ViewModel using a convention, and assign the associated View's <see cref="Microsoft.Maui.Controls.BindableObject.BindingContext"/> to that instance.
-        /// </summary>
-        public static readonly BindableProperty AutowireViewModelProperty =
-            BindableProperty.CreateAttached("AutowireViewModel", typeof(bool?), typeof(ViewModelLocator), null, propertyChanged: OnAutowireViewModelChanged);
+        return (bool?)bindable.GetValue(AutowireViewModelProperty);
+    }
 
-        /// <summary>
-        /// Gets the AutowireViewModel property value.
-        /// </summary>
-        /// <param name="bindable"></param>
-        /// <returns></returns>
-        public static bool? GetAutowireViewModel(BindableObject bindable)
-        {
-            return (bool?)bindable.GetValue(ViewModelLocator.AutowireViewModelProperty);
-        }
+    /// <summary>
+    /// Sets the AutowireViewModel property value.  If <c>true</c>, creates an instance of a ViewModel using a convention, and sets the associated View's <see cref="BindableObject.BindingContext"/> to that instance.
+    /// </summary>
+    /// <param name="bindable"></param>
+    /// <param name="value"></param>
+    public static void SetAutowireViewModel(BindableObject bindable, bool? value)
+    {
+        bindable.SetValue(AutowireViewModelProperty, value);
+    }
 
-        /// <summary>
-        /// Sets the AutowireViewModel property value.  If <c>true</c>, creates an instance of a ViewModel using a convention, and sets the associated View's <see cref="Microsoft.Maui.Controls.BindableObject.BindingContext"/> to that instance.
-        /// </summary>
-        /// <param name="bindable"></param>
-        /// <param name="value"></param>
-        public static void SetAutowireViewModel(BindableObject bindable, bool? value)
+    private static void OnAutowireViewModelChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        bool? bNewValue = (bool?)newValue;
+        if (bNewValue.HasValue && bNewValue.Value)
         {
-            bindable.SetValue(ViewModelLocator.AutowireViewModelProperty, value);
+            var vmType = bindable.GetValue(ViewModelProperty) as Type;
+            if (vmType is null)
+                ViewModelLocationProvider2.AutoWireViewModelChanged(bindable, Bind);
         }
+    }
 
-        private static void OnAutowireViewModelChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            bool? bNewValue = (bool?)newValue;
-            if (bNewValue.HasValue && bNewValue.Value)
-                ViewModelLocationProvider.AutoWireViewModelChanged(bindable, Bind);
-        }
+    private static void OnViewModelPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (newValue == null || bindable.BindingContext != null)
+            return;
+        else if(newValue is Type)
+            bindable.SetValue(AutowireViewModelProperty, true);
+    }
 
-        /// <summary>
-        /// Sets the <see cref="Microsoft.Maui.Controls.BindableObject.BindingContext"/> of a View
-        /// </summary>
-        /// <param name="view">The View to set the <see cref="Microsoft.Maui.Controls.BindableObject.BindingContext"/> on</param>
-        /// <param name="viewModel">The object to use as the <see cref="Microsoft.Maui.Controls.BindableObject.BindingContext"/> for the View</param>
-        private static void Bind(object view, object viewModel)
-        {
-            if (view is BindableObject element)
-                element.BindingContext = viewModel;
-        }
+    /// <summary>
+    /// Sets the <see cref="BindableObject.BindingContext"/> of a View
+    /// </summary>
+    /// <param name="view">The View to set the <see cref="BindableObject.BindingContext"/> on</param>
+    /// <param name="viewModel">The object to use as the <see cref="BindableObject.BindingContext"/> for the View</param>
+    private static void Bind(object view, object viewModel)
+    {
+        if (view is BindableObject element)
+            element.BindingContext = viewModel;
     }
 }

--- a/src/Prism.Maui/Mvvm/ViewModelLocator.cs
+++ b/src/Prism.Maui/Mvvm/ViewModelLocator.cs
@@ -43,9 +43,7 @@ public static class ViewModelLocator
         bool? bNewValue = (bool?)newValue;
         if (bNewValue.HasValue && bNewValue.Value)
         {
-            var vmType = bindable.GetValue(ViewModelProperty) as Type;
-            if (vmType is null)
-                ViewModelLocationProvider2.AutoWireViewModelChanged(bindable, Bind);
+            ViewModelLocationProvider2.AutoWireViewModelChanged(bindable, Bind);
         }
     }
 

--- a/src/Prism.Maui/Navigation/NavigationRegistry.cs
+++ b/src/Prism.Maui/Navigation/NavigationRegistry.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Data;
-using Microsoft.Maui.Controls;
 using Prism.Ioc;
 using Prism.Mvvm;
 
@@ -33,11 +32,19 @@ namespace Prism.Navigation
             if (registration is null)
                 throw new KeyNotFoundException($"No view with the name '{name}' has been registered");
 
-            var view = container.Resolve(registration.View);
-            if (view is BindableObject bindable && bindable.BindingContext is null && (bool?)bindable.GetValue(ViewModelLocator.AutowireViewModelProperty) is null)
-            {
-                ViewModelLocator.SetAutowireViewModel(bindable, true);
-            }
+            var view = container.Resolve(registration.View) as BindableObject;
+
+            // Sanity Check
+            if (view is null)
+                throw new KeyNotFoundException($"No view with the name '{name}' has been registered");
+            else if (view.BindingContext is not null)
+                return view;
+
+            if (registration.ViewModel is not null)
+                view.SetValue(ViewModelLocator.ViewModelProperty, registration.ViewModel);
+
+            else if ((bool?)view.GetValue(ViewModelLocator.AutowireViewModelProperty) is null)
+                ViewModelLocator.SetAutowireViewModel(view, true);
 
             return view;
         }

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -750,10 +750,13 @@ namespace Prism.Navigation
             }
             catch (Exception ex)
             {
-                if (((IContainerRegistry)_container).IsRegistered<object>(segmentName))
-                    throw new NavigationException(NavigationException.ErrorCreatingPage, _page, ex);
+                if (ex is NavigationException)
+                    throw;
 
-                throw new NavigationException(NavigationException.NoPageIsRegistered, _page, ex);
+                else if(ex is KeyNotFoundException)
+                    throw new NavigationException(NavigationException.NoPageIsRegistered, _page, ex);
+
+                throw new NavigationException(NavigationException.ErrorCreatingPage, _page, ex);
             }
         }
 

--- a/src/Prism.Maui/PrismApplication.cs
+++ b/src/Prism.Maui/PrismApplication.cs
@@ -28,7 +28,14 @@ namespace Prism
         /// </summary>
         protected virtual void ConfigureViewModelLocator()
         {
-            ViewModelLocationProvider.SetDefaultViewModelFactory((view, type) =>
+            ViewModelLocationProvider2.SetDefaultViewToViewModelTypeResolver(view =>
+            {
+                if (!(view is BindableObject bindable))
+                    return null;
+
+                return bindable.GetValue(ViewModelLocator.ViewModelProperty) as Type;
+            });
+            ViewModelLocationProvider2.SetDefaultViewModelFactory((view, type) =>
             {
                 var overrides = new List<(Type Type, object Instance)>();
                 if (Container.IsRegistered<IResolverOverridesHelper>())
@@ -71,7 +78,10 @@ namespace Prism
 
         protected sealed override Window CreateWindow(IActivationState activationState)
         {
-            var window = base.CreateWindow(activationState);
+            var window = new Window();
+
+            var windows = Windows as List<Window>;
+            windows.Add(window);
 
             // We need to delay creating the Navigation Service since it
             // requires the IApplication which cannot be resolved from a


### PR DESCRIPTION
# Description

Refactors IServiceScopeFactory & app startup to resolve the StackOverflowException being encountered and killing the app on startup. 

Adds new ViewModelLocationProvider2 with a `ViewToViewModelResolver` so that we can more properly utilize the Navigation Registry. As a result this helps clears the requirement of having named types for Prism's internal use with the container.