### PR TITLE
[BREAKING] ViewModelLocator Autowire - Use Enum

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@ As this is special preview build there are no docs, be sure to check out the sou
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" 
-                      Version="3.5.103"
+                      Version="3.5.104"
                       PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub"
                       Version="1.1.1"

--- a/src/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
+++ b/src/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="5.0.1" />
+    <PackageReference Include="DryIoc.dll" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Prism.Maui/Common/PageUtilities.cs
+++ b/src/Prism.Maui/Common/PageUtilities.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Reflection;
-using Prism.Mvvm;
 using Prism.Navigation;
 using NavigationMode = Prism.Navigation.NavigationMode;
 
@@ -274,26 +273,6 @@ namespace Prism.Common
 
             return potentialDescendant.GetTypeInfo().IsSubclassOf(potentialBase)
                    || potentialDescendant == potentialBase;
-        }
-
-        /// <summary>
-        /// Sets the AutowireViewModel property on the View to <c>true</c> if there is currently
-        /// no BindingContext and the AutowireViewModel property has not been set.
-        /// </summary>
-        /// <param name="element">The View typically a <see cref="Page"/> or <see cref="View"/>.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void SetAutowireViewModel(VisualElement element)
-        {
-            if (element.BindingContext is null && ViewModelLocator.GetAutowireViewModel(element) is null)
-            {
-                ViewModelLocator.SetAutowireViewModel(element, true);
-            }
-            else if (element.BindingContext == element.Parent?.BindingContext)
-            {
-                //if the parent binding context is the same as the element, then it was probably inherited
-                //and we don't want that. Set the VML
-                ViewModelLocator.SetAutowireViewModel(element, true);
-            }
         }
     }
 }

--- a/src/Prism.Maui/Ioc/MicrosoftDependencyInjectionExtensions.cs
+++ b/src/Prism.Maui/Ioc/MicrosoftDependencyInjectionExtensions.cs
@@ -41,6 +41,7 @@ public static class MicrosoftDependencyInjectionExtensions
 
         if (viewModel != null)
             services.AddTransient(viewModel);
+
         return services;
     }
 }

--- a/src/Prism.Maui/Ioc/NavigationRegistrationExtensions.cs
+++ b/src/Prism.Maui/Ioc/NavigationRegistrationExtensions.cs
@@ -26,6 +26,7 @@ namespace Prism.Ioc
 
             if (viewModel != null)
                 container.Register(viewModel);
+
             return container;
         }
     }

--- a/src/Prism.Maui/Mvvm/ViewModelLocatorBehavior.cs
+++ b/src/Prism.Maui/Mvvm/ViewModelLocatorBehavior.cs
@@ -1,0 +1,7 @@
+﻿namespace Prism.Mvvm;
+
+public enum ViewModelLocatorBehavior
+{
+    Automatic,
+    Disabled
+}

--- a/src/Prism.Maui/Navigation/NavigationRegistry.cs
+++ b/src/Prism.Maui/Navigation/NavigationRegistry.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Data;
+using Prism.Behaviors;
+using Prism.Common;
 using Prism.Ioc;
 using Prism.Mvvm;
 
@@ -36,8 +38,13 @@ public static class NavigationRegistry
 
             var view = container.Resolve(registration.View) as BindableObject;
 
+            view.SetValue(Xaml.Navigation.NavigationScopeProperty, container);
+
             if (view is Page page)
-                page.SetValue(Xaml.Navigation.NavigationScopeProperty, container);
+            {
+                var behaviors = container.Resolve<IPageBehaviorFactory>();
+                ConfigurePage(container, page, behaviors);
+            }
 
             if (view.BindingContext is not null)
                 return view;
@@ -45,8 +52,7 @@ public static class NavigationRegistry
             if (registration.ViewModel is not null)
                 view.SetValue(ViewModelLocator.ViewModelProperty, registration.ViewModel);
 
-            else if ((bool?)view.GetValue(ViewModelLocator.AutowireViewModelProperty) is null)
-                ViewModelLocator.SetAutowireViewModel(view, true);
+            ViewModelLocator.Autowire(view);
 
             return view;
         }
@@ -68,4 +74,32 @@ public static class NavigationRegistry
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void ClearRegistrationCache() => _registrations.Clear();
+
+    private static void ConfigurePage(IContainerProvider container, Page page, IPageBehaviorFactory behaviors)
+    {
+        if(page is TabbedPage tabbed)
+        {
+            foreach(var child in tabbed.Children)
+            {
+                var scope = container.CreateScope();
+                ConfigurePage(scope, child, behaviors);
+            }
+        }
+        else if(page is NavigationPage navPage && navPage.RootPage is not null)
+        {
+            var scope = container.CreateScope();
+            ConfigurePage(scope, navPage.RootPage, behaviors);
+        }
+
+        if (page.GetValue(Xaml.Navigation.NavigationScopeProperty) is null)
+            page.SetValue(Xaml.Navigation.NavigationScopeProperty, container);
+
+        var navService = container.Resolve<INavigationService>();
+        if (navService is IPageAware pa)
+            pa.Page = page;
+
+        page.SetValue(Xaml.Navigation.NavigationServiceProperty, navService);
+
+        behaviors.ApplyPageBehaviors(page);
+    }
 }

--- a/src/Prism.Maui/Navigation/NavigationRegistry.cs
+++ b/src/Prism.Maui/Navigation/NavigationRegistry.cs
@@ -67,6 +67,9 @@ public static class NavigationRegistry
         }
     }
 
+    public static bool IsRegistered(string name) =>
+        _registrations.Any(x => x.Name == name);
+
     public static Type GetPageType(string name)
     {
         var registrations = _registrations.Where(x => x.Name == name);

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -104,9 +104,9 @@ public abstract class PrismAppBuilder
         }
 
         var app = _container.Resolve<IApplication>();
-        if (NavigationRegistry.GetPageType(nameof(NavigationPage)) is null)
+        if (!NavigationRegistry.IsRegistered(nameof(NavigationPage)))
             ((IContainerRegistry)_container).RegisterForNavigation<NavigationPage>();
-        if (NavigationRegistry.GetPageType(nameof(TabbedPage)) is null)
+        if (!NavigationRegistry.IsRegistered(nameof(TabbedPage)))
             ((IContainerRegistry)_container).RegisterForNavigation<TabbedPage>();
 
         if (app is ILegacyPrismApplication prismApp)

--- a/tests/Prism.Maui.Tests/Prism.Maui.Tests.csproj
+++ b/tests/Prism.Maui.Tests/Prism.Maui.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
# Description

Prism.Forms initially introduced the ViewModelLocator.Autowire property as an Attached property which would initialize the View with the ViewModel when the property was set to True. In later versions of Prism we opted to make this a default behavior and updated this from a `bool` -> `bool?`. This results in a number of issues as the ViewModel can be initialized too early.

The ViewModelLocatorBehavior enum simply provides options for Automatic & Disabled. By default we will Autowire any View that:

1. Has not explicitly set the Autowire property to Disabled
2. Has a null Binding Context or as would be the case with explicitly declared children in a TabbedPage / NavigationPage not equal to the Parent or Parent Binding Context

- fixes #30 

## Other Changes

- Changes behavior of the NavigationRegistry to throw exceptions when Multiple Registrations are found or when no registrations are found
- Adds IsRegistered check for Prism to utilize when ensuring TabbedPage & NavigationPage are registered
- Adds helper method for future use by a NavigationBuilder to resolve the Navigation key with ViewModel first navigation