### PR TITLE
Adding Navigation Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ MauiApp.CreateBuilder()
     .RegisterServices(container => {
         container.Register<ISomeService, SomeImplementation>();
         container.RegisterForNavigation<ViewA, ViewAViewModel>();
-    }
+    })
     .ConfigureModuleCatalog(catalog => {
         catalog.AddModule<ModuleA>();
     });
@@ -82,6 +82,40 @@ MauiApp.CreateBuilder()
 
 PrismApplication is largely obsolete for Prism.Maui. The PrismAppBuilder does not have an explicit requirement on it. To make it easier on those who are upgrading, we do have legacy support methods to make updating your existing apps a little easier. This includes a `RegisterTypes` & `OnInitialized` method which will get called during the app initialization. It is recommended however that you migrate this code to your App Builder.
 
+## Navigation Builders
+
+Creating a complex navigation stack via a URI can be intimidating for some. For others it can pose a challenge as they require a dynamically built navigation stack. And still other developers have often requested a ViewModel first approach to navigation in Prism. The NavigationBuilder is a great way to help solve these various problems. The NavigationBuilder can be created using an extension on the INavigationService. There is no way to clear the NavigationBuilder, so you should NOT attempt to store this as a property on your ViewModel, and you should instead create a new instance whenever you need to navigate. The samples below are meant to show you some of what is possible. It is not in any way meant as guidance for creating a navigation stack using the most completely random approach possible. Pick a standard approach and follow it. The Builders are meant to expose an API that is easy to use and can help people with different preferences for how to build their navigation stack.
+
+```cs
+// Shown with option OnError callback
+navigationService.CreateBuilder()
+    .AddNavigationSegment("MainPage")
+    .AddNavigationPage()
+    .AddNavigationSegment<ViewAViewModel>()
+    .AddNavigationSegment("ViewB")
+    .Navigate(HandleNavigationError);
+
+// This returns the INavigationResult... 
+// Also available with overloads to provide OnSuccess & OnError callbacks
+navigationService.CreateBuilder()
+    .AddTabbedSegment(b =>
+    {
+        b.CreateTab(t => t.AddNavigationSegment<ViewAViewModel>())
+            .CreateTab("ViewB")
+            .CreateTab(t => t.AddNavigationPage().AddNavigationSegment<ViewCViewModel>())
+            .SelectTab<ViewBViewModel>();
+    })
+    .NavigateAsync();
+```
+
+It's also important to note that the builders will make some attempt to stop you from breaking the MVVM pattern and you will get an exception if you attempt to do:
+
+```cs
+navigationService.CreateBuilder()
+    .AddNavigationSegment<ViewA>()
+    .Navigate();
+```
+
 ## NOTE
 
-Prism.Maui is current an experimental Alpha. Any preview build is largely meant to solicit additional developer feedback. APIs will likely change and break prior to being merged into the Prism repo and released as a fully official build.
+Prism.Maui is currently a Beta. Any preview build is largely meant to solicit additional developer feedback. APIs will likely change and break prior to being merged into the Prism repo and released as a fully official build.

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -1,3 +1,5 @@
 <Project>
-
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 </Project>

--- a/sample/Directory.Build.targets
+++ b/sample/Directory.Build.targets
@@ -1,3 +1,3 @@
 <Project>
-
+  <Import Project="..\src\Prism.Maui\build\Prism.Maui.targets" />
 </Project>

--- a/sample/MauiModule/MauiAppModule.cs
+++ b/sample/MauiModule/MauiAppModule.cs
@@ -1,7 +1,5 @@
 ﻿using MauiModule.ViewModels;
 using MauiModule.Views;
-using Prism.Ioc;
-using Prism.Modularity;
 
 namespace MauiModule
 {

--- a/sample/MauiModule/ViewModels/BaseServices.cs
+++ b/sample/MauiModule/ViewModels/BaseServices.cs
@@ -1,17 +1,13 @@
-﻿using Prism.Navigation;
-using Prism.Services;
+﻿namespace MauiModule.ViewModels;
 
-namespace MauiModule.ViewModels
+public class BaseServices
 {
-    public class BaseServices
+    public BaseServices(INavigationService navigationService, IPageDialogService pageDialogs)
     {
-        public BaseServices(INavigationService navigationService, IPageDialogService pageDialogs)
-        {
-            NavigationService = navigationService;
-            PageDialogs = pageDialogs;
-        }
-
-        public INavigationService NavigationService { get; }
-        public IPageDialogService PageDialogs { get; }
+        NavigationService = navigationService;
+        PageDialogs = pageDialogs;
     }
+
+    public INavigationService NavigationService { get; }
+    public IPageDialogService PageDialogs { get; }
 }

--- a/sample/MauiModule/ViewModels/ViewAViewModel.cs
+++ b/sample/MauiModule/ViewModels/ViewAViewModel.cs
@@ -1,10 +1,9 @@
-﻿namespace MauiModule.ViewModels
+﻿namespace MauiModule.ViewModels;
+
+public class ViewAViewModel : ViewModelBase
 {
-    public class ViewAViewModel : ViewModelBase
+    public ViewAViewModel(BaseServices baseServices) 
+        : base(baseServices)
     {
-        public ViewAViewModel(BaseServices baseServices) 
-            : base(baseServices)
-        {
-        }
     }
 }

--- a/sample/MauiModule/ViewModels/ViewBViewModel.cs
+++ b/sample/MauiModule/ViewModels/ViewBViewModel.cs
@@ -1,10 +1,9 @@
-﻿namespace MauiModule.ViewModels
+﻿namespace MauiModule.ViewModels;
+
+public class ViewBViewModel : ViewModelBase
 {
-    public class ViewBViewModel : ViewModelBase
+    public ViewBViewModel(BaseServices baseServices) 
+        : base(baseServices)
     {
-        public ViewBViewModel(BaseServices baseServices) 
-            : base(baseServices)
-        {
-        }
     }
 }

--- a/sample/MauiModule/ViewModels/ViewCViewModel.cs
+++ b/sample/MauiModule/ViewModels/ViewCViewModel.cs
@@ -1,10 +1,9 @@
-﻿namespace MauiModule.ViewModels
+﻿namespace MauiModule.ViewModels;
+
+public class ViewCViewModel : ViewModelBase
 {
-    public class ViewCViewModel : ViewModelBase
+    public ViewCViewModel(BaseServices baseServices) 
+        : base(baseServices)
     {
-        public ViewCViewModel(BaseServices baseServices) 
-            : base(baseServices)
-        {
-        }
     }
 }

--- a/sample/MauiModule/ViewModels/ViewDViewModel.cs
+++ b/sample/MauiModule/ViewModels/ViewDViewModel.cs
@@ -1,10 +1,9 @@
-﻿namespace MauiModule.ViewModels
+﻿namespace MauiModule.ViewModels;
+
+public class ViewDViewModel : ViewModelBase
 {
-    public class ViewDViewModel : ViewModelBase
+    public ViewDViewModel(BaseServices baseServices) 
+        : base(baseServices)
     {
-        public ViewDViewModel(BaseServices baseServices) 
-            : base(baseServices)
-        {
-        }
     }
 }

--- a/sample/MauiModule/ViewModels/ViewModelBase.cs
+++ b/sample/MauiModule/ViewModels/ViewModelBase.cs
@@ -1,81 +1,74 @@
-﻿using System;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
-using Prism.AppModel;
-using Prism.Commands;
-using Prism.Mvvm;
-using Prism.Navigation;
-using Prism.Services;
 
-namespace MauiModule.ViewModels
+namespace MauiModule.ViewModels;
+
+public abstract class ViewModelBase : BindableBase, IInitialize, INavigatedAware, IPageLifecycleAware
 {
-    public abstract class ViewModelBase : BindableBase, IInitialize, INavigatedAware, IPageLifecycleAware
+    protected INavigationService _navigationService { get; }
+    protected IPageDialogService _pageDialogs { get; }
+
+    protected ViewModelBase(BaseServices baseServices)
     {
-        protected INavigationService _navigationService { get; }
-        protected IPageDialogService _pageDialogs { get; }
-
-        protected ViewModelBase(BaseServices baseServices)
+        _navigationService = baseServices.NavigationService;
+        _pageDialogs = baseServices.PageDialogs;
+        Title = Regex.Replace(GetType().Name, "ViewModel", string.Empty);
+        Id = Guid.NewGuid().ToString();
+        NavigateCommand = new DelegateCommand<string>(OnNavigateCommandExecuted);
+        ShowPageDialog = new DelegateCommand(OnShowPageDialog);
+        Messages = new ObservableCollection<string>();
+        Messages.CollectionChanged += (sender, args) =>
         {
-            _navigationService = baseServices.NavigationService;
-            _pageDialogs = baseServices.PageDialogs;
-            Title = Regex.Replace(GetType().Name, "ViewModel", string.Empty);
-            Id = Guid.NewGuid().ToString();
-            NavigateCommand = new DelegateCommand<string>(OnNavigateCommandExecuted);
-            ShowPageDialog = new DelegateCommand(OnShowPageDialog);
-            Messages = new ObservableCollection<string>();
-            Messages.CollectionChanged += (sender, args) =>
-            {
-                foreach (string message in args.NewItems)
-                    Console.WriteLine($"{Title} - {message}");
-            };
-        }
+            foreach (string message in args.NewItems)
+                Console.WriteLine($"{Title} - {message}");
+        };
+    }
 
-        public string Title { get; }
+    public string Title { get; }
 
-        public string Id { get; }
+    public string Id { get; }
 
-        public ObservableCollection<string> Messages { get; }
+    public ObservableCollection<string> Messages { get; }
 
-        public DelegateCommand<string> NavigateCommand { get; }
+    public DelegateCommand<string> NavigateCommand { get; }
 
-        public DelegateCommand ShowPageDialog { get; }
+    public DelegateCommand ShowPageDialog { get; }
 
-        private void OnNavigateCommandExecuted(string uri)
-        {
-            Messages.Add($"OnNavigateCommandExecuted: {uri}");
-            _navigationService.NavigateAsync(uri)
-                .OnNavigationError(ex => Console.WriteLine(ex));
-        }
+    private void OnNavigateCommandExecuted(string uri)
+    {
+        Messages.Add($"OnNavigateCommandExecuted: {uri}");
+        _navigationService.NavigateAsync(uri)
+            .OnNavigationError(ex => Console.WriteLine(ex));
+    }
 
-        private void OnShowPageDialog()
-        {
-            Messages.Add("OnShowPageDialog");
-            _pageDialogs.DisplayAlertAsync("Message", $"Hello from {Title}. This is a Page Dialog Service Alert!", "Ok");
-        }
+    private void OnShowPageDialog()
+    {
+        Messages.Add("OnShowPageDialog");
+        _pageDialogs.DisplayAlertAsync("Message", $"Hello from {Title}. This is a Page Dialog Service Alert!", "Ok");
+    }
 
-        public void Initialize(INavigationParameters parameters)
-        {
-            Messages.Add("ViewModel Initialized");
-        }
+    public void Initialize(INavigationParameters parameters)
+    {
+        Messages.Add("ViewModel Initialized");
+    }
 
-        public void OnNavigatedFrom(INavigationParameters parameters)
-        {
-            Messages.Add("ViewModel NavigatedFrom");
-        }
+    public void OnNavigatedFrom(INavigationParameters parameters)
+    {
+        Messages.Add("ViewModel NavigatedFrom");
+    }
 
-        public void OnNavigatedTo(INavigationParameters parameters)
-        {
-            Messages.Add("ViewModel NavigatedTo");
-        }
+    public void OnNavigatedTo(INavigationParameters parameters)
+    {
+        Messages.Add("ViewModel NavigatedTo");
+    }
 
-        public void OnAppearing()
-        {
-            Messages.Add("View Appearing");
-        }
+    public void OnAppearing()
+    {
+        Messages.Add("View Appearing");
+    }
 
-        public void OnDisappearing()
-        {
-            Messages.Add("View Disappearing");
-        }
+    public void OnDisappearing()
+    {
+        Messages.Add("View Disappearing");
     }
 }

--- a/sample/MauiModule/ViewModels/ViewModelBase.cs
+++ b/sample/MauiModule/ViewModels/ViewModelBase.cs
@@ -3,12 +3,13 @@ using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 using Prism.AppModel;
 using Prism.Commands;
+using Prism.Mvvm;
 using Prism.Navigation;
 using Prism.Services;
 
 namespace MauiModule.ViewModels
 {
-    public abstract class ViewModelBase : IInitialize, INavigatedAware, IPageLifecycleAware
+    public abstract class ViewModelBase : BindableBase, IInitialize, INavigatedAware, IPageLifecycleAware
     {
         protected INavigationService _navigationService { get; }
         protected IPageDialogService _pageDialogs { get; }

--- a/sample/MauiModule/Views/ViewA.xaml.cs
+++ b/sample/MauiModule/Views/ViewA.xaml.cs
@@ -1,15 +1,9 @@
-using System;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
+namespace MauiModule.Views;
 
-namespace MauiModule.Views
+public partial class ViewA : ContentPage
 {
-    public partial class ViewA : ContentPage
+    public ViewA()
     {
-        public ViewA()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }

--- a/sample/MauiModule/Views/ViewB.xaml.cs
+++ b/sample/MauiModule/Views/ViewB.xaml.cs
@@ -1,15 +1,9 @@
-using System;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
+namespace MauiModule.Views;
 
-namespace MauiModule.Views
+public partial class ViewB : ContentPage
 {
-    public partial class ViewB : ContentPage
+    public ViewB()
     {
-        public ViewB()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }

--- a/sample/MauiModule/Views/ViewC.xaml.cs
+++ b/sample/MauiModule/Views/ViewC.xaml.cs
@@ -1,15 +1,9 @@
-using System;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
+namespace MauiModule.Views;
 
-namespace MauiModule.Views
+public partial class ViewC : ContentPage
 {
-    public partial class ViewC : ContentPage
+    public ViewC()
     {
-        public ViewC()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }

--- a/sample/MauiModule/Views/ViewD.xaml.cs
+++ b/sample/MauiModule/Views/ViewD.xaml.cs
@@ -1,15 +1,9 @@
-using System;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
+namespace MauiModule.Views;
 
-namespace MauiModule.Views
+public partial class ViewD : ContentPage
 {
-    public partial class ViewD : ContentPage
+    public ViewD()
     {
-        public ViewD()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }

--- a/sample/PrismMauiDemo/MauiProgram.cs
+++ b/sample/PrismMauiDemo/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using MauiModule;
+using MauiModule.ViewModels;
 using Prism;
 using Prism.Ioc;
 using Prism.Modularity;
@@ -23,18 +24,31 @@ public static class MauiProgram
                 containerRegistry.RegisterForNavigation<RootPage>();
                 containerRegistry.RegisterForNavigation<SamplePage>();
             })
-            .OnAppStart(async navigationService =>
-            {
-                var result = await navigationService.NavigateAsync("MainPage/NavigationPage/ViewA/ViewB/ViewC/ViewD");
-                if (!result.Success)
-                {
-                    System.Diagnostics.Debugger.Break();
-                }
-            })
+            .OnAppStart(navigationService => navigationService.CreateBuilder()
+                .AddNavigationSegment("MainPage")
+                .AddNavigationPage()
+                .AddNavigationSegment<ViewAViewModel>()
+                .AddNavigationSegment("ViewB")
+                .Navigate(HandleNavigationError))
+            //.OnAppStart(async navigationService =>
+            //{
+                
+            //    var result = await navigationService.NavigateAsync("MainPage/NavigationPage/ViewA/ViewB/ViewC/ViewD");
+            //    if (!result.Success)
+            //    {
+            //        System.Diagnostics.Debugger.Break();
+            //    }
+            //})
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
             })
             .Build();
+    }
+
+    private static void HandleNavigationError(Exception ex)
+    {
+        Console.WriteLine(ex);
+        System.Diagnostics.Debugger.Break();
     }
 }

--- a/sample/PrismMauiDemo/MauiProgram.cs
+++ b/sample/PrismMauiDemo/MauiProgram.cs
@@ -1,9 +1,5 @@
 ﻿using MauiModule;
 using MauiModule.ViewModels;
-using Prism;
-using Prism.Ioc;
-using Prism.Modularity;
-using Prism.Navigation;
 using PrismMauiDemo.Views;
 
 namespace PrismMauiDemo;

--- a/sample/PrismMauiDemo/PrismMauiDemo.csproj
+++ b/sample/PrismMauiDemo/PrismMauiDemo.csproj
@@ -7,7 +7,6 @@
     <RootNamespace>PrismMauiDemo</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
-    <ImplicitUsings>enable</ImplicitUsings>
     <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 
     <!-- Display name -->

--- a/sample/PrismMauiDemo/ViewModels/MainPageViewModel.cs
+++ b/sample/PrismMauiDemo/ViewModels/MainPageViewModel.cs
@@ -1,25 +1,20 @@
-﻿using Prism.Commands;
-using System;
-using Prism.Navigation;
+﻿namespace PrismMauiDemo.ViewModels;
 
-namespace PrismMauiDemo.ViewModels
+internal class MainPageViewModel
 {
-    internal class MainPageViewModel
+    private INavigationService _navigationService { get; }
+
+    public MainPageViewModel(INavigationService navigationService)
     {
-        private INavigationService _navigationService { get; }
+        _navigationService = navigationService;
+        NavigateCommand = new DelegateCommand<string>(OnNavigateCommandExecuted);
+    }
 
-        public MainPageViewModel(INavigationService navigationService)
-        {
-            _navigationService = navigationService;
-            NavigateCommand = new DelegateCommand<string>(OnNavigateCommandExecuted);
-        }
+    public DelegateCommand<string> NavigateCommand { get; }
 
-        public DelegateCommand<string> NavigateCommand { get; }
-
-        private void OnNavigateCommandExecuted(string uri)
-        {
-            _navigationService.NavigateAsync(uri)
-                .OnNavigationError(ex => Console.WriteLine(ex));
-        }
+    private void OnNavigateCommandExecuted(string uri)
+    {
+        _navigationService.NavigateAsync(uri)
+            .OnNavigationError(ex => Console.WriteLine(ex));
     }
 }

--- a/sample/PrismMauiDemo/ViewModels/RootPageViewModel.cs
+++ b/sample/PrismMauiDemo/ViewModels/RootPageViewModel.cs
@@ -1,7 +1,4 @@
-﻿using Prism.Commands;
-using Prism.Navigation;
-
-namespace PrismMauiDemo.ViewModels;
+﻿namespace PrismMauiDemo.ViewModels;
 
 public class RootPageViewModel
 {

--- a/sample/PrismMauiDemo/Views/MainPage.xaml.cs
+++ b/sample/PrismMauiDemo/Views/MainPage.xaml.cs
@@ -1,8 +1,3 @@
-using System;
-using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Xaml;
-
 namespace PrismMauiDemo.Views;
 
 public partial class MainPage : FlyoutPage

--- a/sample/PrismMauiDemo/Views/RootPage.xaml.cs
+++ b/sample/PrismMauiDemo/Views/RootPage.xaml.cs
@@ -2,8 +2,8 @@ namespace PrismMauiDemo.Views;
 
 public partial class RootPage : ContentPage
 {
-	public RootPage()
-	{
-		InitializeComponent();
-	}
+    public RootPage()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Prism.Maui/AppModel/FlowDirection.cs
+++ b/src/Prism.Maui/AppModel/FlowDirection.cs
@@ -1,40 +1,39 @@
-﻿namespace Prism.AppModel
+﻿namespace Prism.AppModel;
+
+/// <summary>
+/// Enumerates values that control the layout direction for views. This maps to
+/// the Microsoft.Maui.Controls.FlowDirection.
+/// </summary>
+/// <remarks>
+/// The following contains a few important points from Right-to-Left Localization.
+/// Developers should consult that document for more information about limitations
+/// of right-to-left support, and for requirements to implement right-to-left support
+/// on various target platforms.
+/// The default value of Microsoft.Maui.Controls.FlowDirection for a visual element that has
+/// no parent is Microsoft.Maui.Controls.FlowDirection.LeftToRight, even on platforms where
+/// Microsoft.Maui.Controls.Device.FlowDirection is Microsoft.Maui.Controls.FlowDirection.RightToLeft.
+/// Therefore, developers must deliberately opt in to right-to-left layout. Developers
+/// can choose right-to-left layout by setting the Microsoft.Maui.Controls.VisualElement.FlowDirection
+/// property of the root element to Microsoft.Maui.Controls.FlowDirection.RightToLeft to choose
+/// right-to-left layout, or to Microsoft.Maui.Controls.FlowDirection.MatchParent to match
+/// the device layout.
+/// </remarks>
+public enum FlowDirection
 {
     /// <summary>
-    /// Enumerates values that control the layout direction for views. This maps to
-    /// the Microsoft.Maui.Controls.FlowDirection.
+    /// Indicates that the view's layout direction will match the parent view's layout
+    /// direction.
     /// </summary>
-    /// <remarks>
-    /// The following contains a few important points from Right-to-Left Localization.
-    /// Developers should consult that document for more information about limitations
-    /// of right-to-left support, and for requirements to implement right-to-left support
-    /// on various target platforms.
-    /// The default value of Microsoft.Maui.Controls.FlowDirection for a visual element that has
-    /// no parent is Microsoft.Maui.Controls.FlowDirection.LeftToRight, even on platforms where
-    /// Microsoft.Maui.Controls.Device.FlowDirection is Microsoft.Maui.Controls.FlowDirection.RightToLeft.
-    /// Therefore, developers must deliberately opt in to right-to-left layout. Developers
-    /// can choose right-to-left layout by setting the Microsoft.Maui.Controls.VisualElement.FlowDirection
-    /// property of the root element to Microsoft.Maui.Controls.FlowDirection.RightToLeft to choose
-    /// right-to-left layout, or to Microsoft.Maui.Controls.FlowDirection.MatchParent to match
-    /// the device layout.
-    /// </remarks>
-    public enum FlowDirection
-    {
-        /// <summary>
-        /// Indicates that the view's layout direction will match the parent view's layout
-        /// direction.
-        /// </summary>
-        MatchParent = 0,
+    MatchParent = 0,
 
-        /// <summary>
-        /// Indicates that view will be laid out left to right. This is the default when
-        /// the view has no parent.
-        /// </summary>
-        LeftToRight = 1,
+    /// <summary>
+    /// Indicates that view will be laid out left to right. This is the default when
+    /// the view has no parent.
+    /// </summary>
+    LeftToRight = 1,
 
-        /// <summary>
-        /// Indicates that view will be laid out right to left.
-        /// </summary>
-        RightToLeft = 2,
-    }
+    /// <summary>
+    /// Indicates that view will be laid out right to left.
+    /// </summary>
+    RightToLeft = 2,
 }

--- a/src/Prism.Maui/AppModel/IKeyboardMapper.cs
+++ b/src/Prism.Maui/AppModel/IKeyboardMapper.cs
@@ -1,17 +1,14 @@
-﻿using Microsoft.Maui;
+﻿namespace Prism.AppModel;
 
-namespace Prism.AppModel
+/// <summary>
+/// An abstraction to map <see cref="KeyboardType"/> to the <see cref="Keyboard"/>;
+/// </summary>
+public interface IKeyboardMapper
 {
     /// <summary>
-    /// An abstraction to map <see cref="KeyboardType"/> to the <see cref="Keyboard"/>;
+    /// Maps the <see cref="KeyboardType"/> to a <see cref="Keyboard"/>
     /// </summary>
-    public interface IKeyboardMapper
-    {
-        /// <summary>
-        /// Maps the <see cref="KeyboardType"/> to a <see cref="Keyboard"/>
-        /// </summary>
-        /// <param name="keyboardType">The Keyboard type.</param>
-        /// <returns>The <see cref="Keyboard"/>.</returns>
-        Keyboard Map(KeyboardType keyboardType);
-    }
+    /// <param name="keyboardType">The Keyboard type.</param>
+    /// <returns>The <see cref="Keyboard"/>.</returns>
+    Keyboard Map(KeyboardType keyboardType);
 }

--- a/src/Prism.Maui/AppModel/IPageLifecycleAware.cs
+++ b/src/Prism.Maui/AppModel/IPageLifecycleAware.cs
@@ -1,8 +1,7 @@
-﻿namespace Prism.AppModel
+﻿namespace Prism.AppModel;
+
+public interface IPageLifecycleAware
 {
-    public interface IPageLifecycleAware
-    {
-        void OnAppearing();
-        void OnDisappearing();
-    }
+    void OnAppearing();
+    void OnDisappearing();
 }

--- a/src/Prism.Maui/AppModel/KeyboardMapper.cs
+++ b/src/Prism.Maui/AppModel/KeyboardMapper.cs
@@ -1,31 +1,28 @@
-﻿using Microsoft.Maui;
+﻿namespace Prism.AppModel;
 
-namespace Prism.AppModel
+/// <summary>
+/// The default implementation of the <see cref="IKeyboardMapper"/>.
+/// </summary>
+public class KeyboardMapper : IKeyboardMapper
 {
     /// <summary>
-    /// The default implementation of the <see cref="IKeyboardMapper"/>.
+    /// Maps the <see cref="KeyboardType"/> to a <see cref="Keyboard"/>
     /// </summary>
-    public class KeyboardMapper : IKeyboardMapper
+    /// <param name="keyboardType">The Keyboard type.</param>
+    /// <returns>The <see cref="Keyboard"/>.</returns>
+    public virtual Keyboard Map(KeyboardType keyboardType)
     {
-        /// <summary>
-        /// Maps the <see cref="KeyboardType"/> to a <see cref="Keyboard"/>
-        /// </summary>
-        /// <param name="keyboardType">The Keyboard type.</param>
-        /// <returns>The <see cref="Keyboard"/>.</returns>
-        public virtual Keyboard Map(KeyboardType keyboardType)
+        return keyboardType switch
         {
-            return keyboardType switch
-            {
-                KeyboardType.Chat => Keyboard.Chat,
-                KeyboardType.Default => Keyboard.Default,
-                KeyboardType.Email => Keyboard.Email,
-                KeyboardType.Numeric => Keyboard.Numeric,
-                KeyboardType.Plain => Keyboard.Plain,
-                KeyboardType.Telephone => Keyboard.Telephone,
-                KeyboardType.Text => Keyboard.Text,
-                KeyboardType.Url => Keyboard.Url,
-                _ => throw new NotImplementedException($"The Keyboard Type value {keyboardType} is not supported. Please create and register an implementation of IKeyboardMapper to support this value.")
-            };
-        }
+            KeyboardType.Chat => Keyboard.Chat,
+            KeyboardType.Default => Keyboard.Default,
+            KeyboardType.Email => Keyboard.Email,
+            KeyboardType.Numeric => Keyboard.Numeric,
+            KeyboardType.Plain => Keyboard.Plain,
+            KeyboardType.Telephone => Keyboard.Telephone,
+            KeyboardType.Text => Keyboard.Text,
+            KeyboardType.Url => Keyboard.Url,
+            _ => throw new NotImplementedException($"The Keyboard Type value {keyboardType} is not supported. Please create and register an implementation of IKeyboardMapper to support this value.")
+        };
     }
 }

--- a/src/Prism.Maui/AppModel/KeyboardType.cs
+++ b/src/Prism.Maui/AppModel/KeyboardType.cs
@@ -1,48 +1,47 @@
-﻿namespace Prism.AppModel
+﻿namespace Prism.AppModel;
+
+/// <summary>
+/// Keyboard type
+/// </summary>
+public enum KeyboardType
 {
     /// <summary>
-    /// Keyboard type
+    /// Gets an instance of type "ChatKeyboard".
     /// </summary>
-    public enum KeyboardType
-    {
-        /// <summary>
-        /// Gets an instance of type "ChatKeyboard".
-        /// </summary>
-        Chat,
+    Chat,
 
-        /// <summary>
-        /// Gets an instance of type "Keyboard".
-        /// </summary>
-        Default,
+    /// <summary>
+    /// Gets an instance of type "Keyboard".
+    /// </summary>
+    Default,
 
-        /// <summary>
-        /// Gets an instance of type "EmailKeyboard".
-        /// </summary>
-        Email,
+    /// <summary>
+    /// Gets an instance of type "EmailKeyboard".
+    /// </summary>
+    Email,
 
-        /// <summary>
-        /// Gets an instance of type "NumericKeyboard".
-        /// </summary>
-        Numeric,
+    /// <summary>
+    /// Gets an instance of type "NumericKeyboard".
+    /// </summary>
+    Numeric,
 
-        /// <summary>
-        /// Returns a new keyboard with None Microsoft.Maui.KeyboardFlags.
-        /// </summary>
-        Plain,
+    /// <summary>
+    /// Returns a new keyboard with None Microsoft.Maui.KeyboardFlags.
+    /// </summary>
+    Plain,
 
-        /// <summary>
-        /// Gets an instance of type "TelephoneKeyboard".
-        /// </summary>
-        Telephone,
+    /// <summary>
+    /// Gets an instance of type "TelephoneKeyboard".
+    /// </summary>
+    Telephone,
 
-        /// <summary>
-        /// Gets an instance of type "TextKeyboard".
-        /// </summary>
-        Text,
+    /// <summary>
+    /// Gets an instance of type "TextKeyboard".
+    /// </summary>
+    Text,
 
-        /// <summary>
-        /// Gets an instance of type "UrlKeyboard".
-        /// </summary>
-        Url,
-    }
+    /// <summary>
+    /// Gets an instance of type "UrlKeyboard".
+    /// </summary>
+    Url,
 }

--- a/src/Prism.Maui/Behaviors/BehaviorBase{T}.cs
+++ b/src/Prism.Maui/Behaviors/BehaviorBase{T}.cs
@@ -1,50 +1,47 @@
-﻿using Microsoft.Maui.Controls;
+﻿namespace Prism.Behaviors;
 
-namespace Prism.Behaviors
+/// <summary>
+/// Base class that extends on Xamarin Forms Behaviors.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class BehaviorBase<T> : Behavior<T> where T : BindableObject
 {
     /// <summary>
-    /// Base class that extends on Xamarin Forms Behaviors.
+    /// The Object associated with the Behavior
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class BehaviorBase<T> : Behavior<T> where T : BindableObject
+    public T AssociatedObject { get; private set; }
+
+    /// <inheritDoc />
+    protected override void OnAttachedTo(T bindable)
     {
-        /// <summary>
-        /// The Object associated with the Behavior
-        /// </summary>
-        public T AssociatedObject { get; private set; }
+        base.OnAttachedTo(bindable);
+        AssociatedObject = bindable;
 
-        /// <inheritDoc />
-        protected override void OnAttachedTo(T bindable)
+        if (bindable.BindingContext != null)
         {
-            base.OnAttachedTo(bindable);
-            AssociatedObject = bindable;
-
-            if (bindable.BindingContext != null)
-            {
-                BindingContext = bindable.BindingContext;
-            }
-
-            bindable.BindingContextChanged += OnBindingContextChanged;
+            BindingContext = bindable.BindingContext;
         }
 
-        /// <inheritDoc />
-        protected override void OnDetachingFrom(T bindable)
-        {
-            base.OnDetachingFrom(bindable);
-            bindable.BindingContextChanged -= OnBindingContextChanged;
-            AssociatedObject = null;
-        }
+        bindable.BindingContextChanged += OnBindingContextChanged;
+    }
 
-        void OnBindingContextChanged(object sender, EventArgs e)
-        {
-            OnBindingContextChanged();
-        }
+    /// <inheritDoc />
+    protected override void OnDetachingFrom(T bindable)
+    {
+        base.OnDetachingFrom(bindable);
+        bindable.BindingContextChanged -= OnBindingContextChanged;
+        AssociatedObject = null;
+    }
 
-        /// <inheritDoc />
-        protected override void OnBindingContextChanged()
-        {
-            base.OnBindingContextChanged();
-            BindingContext = AssociatedObject.BindingContext;
-        }
+    void OnBindingContextChanged(object sender, EventArgs e)
+    {
+        OnBindingContextChanged();
+    }
+
+    /// <inheritDoc />
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        BindingContext = AssociatedObject.BindingContext;
     }
 }

--- a/src/Prism.Maui/Behaviors/EventToCommandBehavior.cs
+++ b/src/Prism.Maui/Behaviors/EventToCommandBehavior.cs
@@ -2,249 +2,247 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Windows.Input;
-using Microsoft.Maui.Controls;
 
-namespace Prism.Behaviors
+namespace Prism.Behaviors;
+
+/// <summary>
+/// Behavior class that enable using <see cref="ICommand" /> to react on events raised by <see cref="BindableObject" /> bindable.
+/// </summary>
+/// <para>
+/// There are multiple ways to pass a parameter to the <see cref="ICommand.Execute"/> method. 
+/// Setting the <see cref="CommandParameter"/> will always result in that value will be sent.
+/// The <see cref="EventArgsParameterPath"/> will walk the property path on the instance of <see cref="EventArgs"/> for the event and, if any property found, pass that parameter.
+/// The <see cref="EventArgsConverter"/> will call the <see cref="IValueConverter.Convert"/> method with the <see cref="EventArgsConverterParameter"/> and pass the result as parameter.
+/// </para>
+/// <para>
+/// The order of evaluation for the parameter to be sent to the <see cref="ICommand.Execute"/> method is
+/// 1. <see cref="CommandParameter"/>
+/// 2. <see cref="EventArgsParameterPath"/>
+/// 3. <see cref="EventArgsConverter"/>
+/// and as soon as a non-<c>null</c> value is found, the evaluation is stopped.
+/// </para>
+/// <example>
+/// &lt;ListView&gt;
+/// &lt;ListView.Behaviors&gt;
+/// &lt;behaviors:EventToCommandBehavior EventName="ItemTapped" Command={Binding ItemTappedCommand} /&gt;
+/// &lt;/ListView.Behaviors&gt;
+/// &lt;/ListView&gt;
+/// </example>
+// This is a modified version of https://anthonysimmon.com/eventtocommand-in-xamarin-forms-apps/
+public class EventToCommandBehavior : BehaviorBase<BindableObject>
 {
     /// <summary>
-    /// Behavior class that enable using <see cref="ICommand" /> to react on events raised by <see cref="BindableObject" /> bindable.
+    /// Bindable property for Name of the event that will be forwarded to 
+    /// <see cref="EventToCommandBehavior.Command"/>
+    /// </summary>
+    public static readonly BindableProperty EventNameProperty =
+        BindableProperty.Create(nameof(EventName), typeof(string), typeof(EventToCommandBehavior));
+
+    /// <summary>
+    /// Bindable property for Command to execute
+    /// </summary>
+    public static readonly BindableProperty CommandProperty =
+        BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(EventToCommandBehavior));
+
+    /// <summary>
+    /// Bindable property for Argument sent to <see cref="ICommand.Execute(object)"/>
+    /// </summary>
+    public static readonly BindableProperty CommandParameterProperty =
+        BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(EventToCommandBehavior));
+
+    /// <summary>
+    /// Bindable property to set instance of <see cref="IValueConverter" /> to convert the <see cref="EventArgs" /> for <see cref="EventName" />
+    /// </summary>
+    public static readonly BindableProperty EventArgsConverterProperty =
+        BindableProperty.Create(nameof(EventArgsConverter), typeof(IValueConverter), typeof(EventToCommandBehavior));
+
+    /// <summary>
+    /// Bindable property to set Argument passed as parameter to <see cref="IValueConverter.Convert" />
+    /// </summary>
+    public static readonly BindableProperty EventArgsConverterParameterProperty =
+        BindableProperty.Create(nameof(EventArgsConverterParameter), typeof(object), typeof(EventToCommandBehavior));
+
+    /// <summary>
+    /// Bindable property to set Parameter path to extract property from <see cref="EventArgs"/> instance to pass to <see cref="ICommand.Execute"/>
+    /// </summary>
+    public static readonly BindableProperty EventArgsParameterPathProperty =
+        BindableProperty.Create(
+            nameof(EventArgsParameterPath),
+            typeof(string),
+            typeof(EventToCommandBehavior));
+
+    /// <summary>
+    /// <see cref="EventInfo"/>
+    /// </summary>
+    protected EventInfo _eventInfo;
+
+    /// <summary>
+    /// Delegate to Invoke when event is raised
+    /// </summary>
+    protected Delegate _handler;
+
+    /// <summary>
+    /// Parameter path to extract property from <see cref="EventArgs"/> instance to pass to <see cref="ICommand.Execute"/>
+    /// </summary>
+    public string EventArgsParameterPath
+    {
+        get => (string)GetValue(EventArgsParameterPathProperty);
+        set => SetValue(EventArgsParameterPathProperty, value);
+    }
+
+    /// <summary>
+    /// Name of the event that will be forwarded to <see cref="Command" />
+    /// </summary>
+    /// <remarks>
+    /// An event that is invalid for the attached <see cref="View" /> will result in <see cref="ArgumentException" /> thrown.
+    /// </remarks>
+    public string EventName
+    {
+        get => (string)GetValue(EventNameProperty);
+        set => SetValue(EventNameProperty, value);
+    }
+
+    /// <summary>
+    /// The command to execute
+    /// </summary>
+    public ICommand Command
+    {
+        get => (ICommand)GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    /// <summary>
+    /// Argument sent to <see cref="ICommand.Execute" />
     /// </summary>
     /// <para>
-    /// There are multiple ways to pass a parameter to the <see cref="ICommand.Execute"/> method. 
-    /// Setting the <see cref="CommandParameter"/> will always result in that value will be sent.
-    /// The <see cref="EventArgsParameterPath"/> will walk the property path on the instance of <see cref="EventArgs"/> for the event and, if any property found, pass that parameter.
-    /// The <see cref="EventArgsConverter"/> will call the <see cref="IValueConverter.Convert"/> method with the <see cref="EventArgsConverterParameter"/> and pass the result as parameter.
+    /// If <see cref="EventArgsConverter" /> and <see cref="EventArgsConverterParameter" /> is set then the result of the
+    /// conversion
+    /// will be sent.
     /// </para>
-    /// <para>
-    /// The order of evaluation for the parameter to be sent to the <see cref="ICommand.Execute"/> method is
-    /// 1. <see cref="CommandParameter"/>
-    /// 2. <see cref="EventArgsParameterPath"/>
-    /// 3. <see cref="EventArgsConverter"/>
-    /// and as soon as a non-<c>null</c> value is found, the evaluation is stopped.
-    /// </para>
-    /// <example>
-    /// &lt;ListView&gt;
-    /// &lt;ListView.Behaviors&gt;
-    /// &lt;behaviors:EventToCommandBehavior EventName="ItemTapped" Command={Binding ItemTappedCommand} /&gt;
-    /// &lt;/ListView.Behaviors&gt;
-    /// &lt;/ListView&gt;
-    /// </example>
-    // This is a modified version of https://anthonysimmon.com/eventtocommand-in-xamarin-forms-apps/
-    public class EventToCommandBehavior : BehaviorBase<BindableObject>
+    public object CommandParameter
     {
-        /// <summary>
-        /// Bindable property for Name of the event that will be forwarded to 
-        /// <see cref="EventToCommandBehavior.Command"/>
-        /// </summary>
-        public static readonly BindableProperty EventNameProperty =
-            BindableProperty.Create(nameof(EventName), typeof(string), typeof(EventToCommandBehavior));
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
 
-        /// <summary>
-        /// Bindable property for Command to execute
-        /// </summary>
-        public static readonly BindableProperty CommandProperty =
-            BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(EventToCommandBehavior));
+    /// <summary>
+    /// Instance of <see cref="IValueConverter" /> to convert the <see cref="EventArgs" /> for <see cref="EventName" />
+    /// </summary>
+    public IValueConverter EventArgsConverter
+    {
+        get => (IValueConverter)GetValue(EventArgsConverterProperty);
+        set => SetValue(EventArgsConverterProperty, value);
+    }
 
-        /// <summary>
-        /// Bindable property for Argument sent to <see cref="ICommand.Execute(object)"/>
-        /// </summary>
-        public static readonly BindableProperty CommandParameterProperty =
-            BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(EventToCommandBehavior));
+    /// <summary>
+    /// Argument passed as parameter to <see cref="IValueConverter.Convert" />
+    /// </summary>
+    public object EventArgsConverterParameter
+    {
+        get => GetValue(EventArgsConverterParameterProperty);
+        set => SetValue(EventArgsConverterParameterProperty, value);
+    }
 
-        /// <summary>
-        /// Bindable property to set instance of <see cref="IValueConverter" /> to convert the <see cref="EventArgs" /> for <see cref="EventName" />
-        /// </summary>
-        public static readonly BindableProperty EventArgsConverterProperty =
-            BindableProperty.Create(nameof(EventArgsConverter), typeof(IValueConverter), typeof(EventToCommandBehavior));
+    /// <summary>
+    /// Subscribes to the event <see cref="BindableObject"/> object
+    /// </summary>
+    /// <param name="bindable">Bindable object that is source of event to Attach</param>
+    /// <exception cref="ArgumentException">Thrown if no matching event exists on 
+    /// <see cref="BindableObject"/></exception>
+    protected override void OnAttachedTo(BindableObject bindable)
+    {
+        base.OnAttachedTo(bindable);
 
-        /// <summary>
-        /// Bindable property to set Argument passed as parameter to <see cref="IValueConverter.Convert" />
-        /// </summary>
-        public static readonly BindableProperty EventArgsConverterParameterProperty =
-            BindableProperty.Create(nameof(EventArgsConverterParameter), typeof(object), typeof(EventToCommandBehavior));
-
-        /// <summary>
-        /// Bindable property to set Parameter path to extract property from <see cref="EventArgs"/> instance to pass to <see cref="ICommand.Execute"/>
-        /// </summary>
-        public static readonly BindableProperty EventArgsParameterPathProperty =
-            BindableProperty.Create(
-                nameof(EventArgsParameterPath),
-                typeof(string),
-                typeof(EventToCommandBehavior));
-
-        /// <summary>
-        /// <see cref="EventInfo"/>
-        /// </summary>
-        protected EventInfo _eventInfo;
-
-        /// <summary>
-        /// Delegate to Invoke when event is raised
-        /// </summary>
-        protected Delegate _handler;
-
-        /// <summary>
-        /// Parameter path to extract property from <see cref="EventArgs"/> instance to pass to <see cref="ICommand.Execute"/>
-        /// </summary>
-        public string EventArgsParameterPath
+        _eventInfo = AssociatedObject
+            .GetType()
+            .GetRuntimeEvent(EventName);
+        if (_eventInfo == null)
         {
-            get => (string)GetValue(EventArgsParameterPathProperty);
-            set => SetValue(EventArgsParameterPathProperty, value);
+            throw new ArgumentException(
+                $"No matching event '{EventName}' on attached type '{bindable.GetType().Name}'");
         }
 
-        /// <summary>
-        /// Name of the event that will be forwarded to <see cref="Command" />
-        /// </summary>
-        /// <remarks>
-        /// An event that is invalid for the attached <see cref="View" /> will result in <see cref="ArgumentException" /> thrown.
-        /// </remarks>
-        public string EventName
+        AddEventHandler(_eventInfo, AssociatedObject, OnEventRaised);
+    }
+
+    /// <summary>
+    /// Unsubscribes from the event on <paramref name="bindable"/>
+    /// </summary>
+    /// <param name="bindable"><see cref="BindableObject"/> that is source of event</param>
+    protected override void OnDetachingFrom(BindableObject bindable)
+    {
+        if (_handler != null)
         {
-            get => (string)GetValue(EventNameProperty);
-            set => SetValue(EventNameProperty, value);
+            _eventInfo.RemoveEventHandler(AssociatedObject, _handler);
+        }
+        _handler = null;
+        _eventInfo = null;
+        base.OnDetachingFrom(bindable);
+    }
+
+    private void AddEventHandler(EventInfo eventInfo, object item, Action<object, EventArgs> action)
+    {
+        var eventParameters = eventInfo.EventHandlerType
+            .GetRuntimeMethods().First(m => m.Name == "Invoke")
+            .GetParameters()
+            .Select(p => Expression.Parameter(p.ParameterType))
+            .ToArray();
+
+        var actionInvoke = action.GetType()
+            .GetRuntimeMethods().First(m => m.Name == "Invoke");
+
+        _handler = Expression.Lambda(
+            eventInfo.EventHandlerType,
+            Expression.Call(Expression.Constant(action), actionInvoke, eventParameters[0], eventParameters[1]),
+            eventParameters)
+            .Compile();
+
+        eventInfo.AddEventHandler(item, _handler);
+    }
+
+    /// <summary>
+    /// Method called when event is raised
+    /// </summary>
+    /// <param name="sender">Source of that raised the event</param>
+    /// <param name="eventArgs">Arguments of the raised event</param>
+    protected virtual void OnEventRaised(object sender, EventArgs eventArgs)
+    {
+        if (Command == null)
+        {
+            return;
         }
 
-        /// <summary>
-        /// The command to execute
-        /// </summary>
-        public ICommand Command
-        {
-            get => (ICommand)GetValue(CommandProperty);
-            set => SetValue(CommandProperty, value);
-        }
+        var parameter = CommandParameter;
 
-        /// <summary>
-        /// Argument sent to <see cref="ICommand.Execute" />
-        /// </summary>
-        /// <para>
-        /// If <see cref="EventArgsConverter" /> and <see cref="EventArgsConverterParameter" /> is set then the result of the
-        /// conversion
-        /// will be sent.
-        /// </para>
-        public object CommandParameter
+        if (parameter == null && !string.IsNullOrEmpty(EventArgsParameterPath))
         {
-            get => GetValue(CommandParameterProperty);
-            set => SetValue(CommandParameterProperty, value);
-        }
-
-        /// <summary>
-        /// Instance of <see cref="IValueConverter" /> to convert the <see cref="EventArgs" /> for <see cref="EventName" />
-        /// </summary>
-        public IValueConverter EventArgsConverter
-        {
-            get => (IValueConverter)GetValue(EventArgsConverterProperty);
-            set => SetValue(EventArgsConverterProperty, value);
-        }
-
-        /// <summary>
-        /// Argument passed as parameter to <see cref="IValueConverter.Convert" />
-        /// </summary>
-        public object EventArgsConverterParameter
-        {
-            get => GetValue(EventArgsConverterParameterProperty);
-            set => SetValue(EventArgsConverterParameterProperty, value);
-        }
-
-        /// <summary>
-        /// Subscribes to the event <see cref="BindableObject"/> object
-        /// </summary>
-        /// <param name="bindable">Bindable object that is source of event to Attach</param>
-        /// <exception cref="ArgumentException">Thrown if no matching event exists on 
-        /// <see cref="BindableObject"/></exception>
-        protected override void OnAttachedTo(BindableObject bindable)
-        {
-            base.OnAttachedTo(bindable);
-
-            _eventInfo = AssociatedObject
-                .GetType()
-                .GetRuntimeEvent(EventName);
-            if (_eventInfo == null)
+            //Walk the ParameterPath for nested properties.
+            var propertyPathParts = EventArgsParameterPath.Split('.');
+            object propertyValue = eventArgs;
+            foreach (var propertyPathPart in propertyPathParts)
             {
-                throw new ArgumentException(
-                    $"No matching event '{EventName}' on attached type '{bindable.GetType().Name}'");
-            }
+                var propInfo = propertyValue.GetType().GetRuntimeProperty(propertyPathPart);
+                if (propInfo == null)
+                    throw new MissingMemberException($"Unable to find {EventArgsParameterPath}");
 
-            AddEventHandler(_eventInfo, AssociatedObject, OnEventRaised);
-        }
-
-        /// <summary>
-        /// Unsubscribes from the event on <paramref name="bindable"/>
-        /// </summary>
-        /// <param name="bindable"><see cref="BindableObject"/> that is source of event</param>
-        protected override void OnDetachingFrom(BindableObject bindable)
-        {
-            if (_handler != null)
-            {
-                _eventInfo.RemoveEventHandler(AssociatedObject, _handler);
-            }
-            _handler = null;
-            _eventInfo = null;
-            base.OnDetachingFrom(bindable);
-        }
-
-        private void AddEventHandler(EventInfo eventInfo, object item, Action<object, EventArgs> action)
-        {
-            var eventParameters = eventInfo.EventHandlerType
-                .GetRuntimeMethods().First(m => m.Name == "Invoke")
-                .GetParameters()
-                .Select(p => Expression.Parameter(p.ParameterType))
-                .ToArray();
-
-            var actionInvoke = action.GetType()
-                .GetRuntimeMethods().First(m => m.Name == "Invoke");
-
-            _handler = Expression.Lambda(
-                eventInfo.EventHandlerType,
-                Expression.Call(Expression.Constant(action), actionInvoke, eventParameters[0], eventParameters[1]),
-                eventParameters)
-                .Compile();
-
-            eventInfo.AddEventHandler(item, _handler);
-        }
-
-        /// <summary>
-        /// Method called when event is raised
-        /// </summary>
-        /// <param name="sender">Source of that raised the event</param>
-        /// <param name="eventArgs">Arguments of the raised event</param>
-        protected virtual void OnEventRaised(object sender, EventArgs eventArgs)
-        {
-            if (Command == null)
-            {
-                return;
-            }
-
-            var parameter = CommandParameter;
-
-            if (parameter == null && !string.IsNullOrEmpty(EventArgsParameterPath))
-            {
-                //Walk the ParameterPath for nested properties.
-                var propertyPathParts = EventArgsParameterPath.Split('.');
-                object propertyValue = eventArgs;
-                foreach (var propertyPathPart in propertyPathParts)
+                propertyValue = propInfo.GetValue(propertyValue);
+                if (propertyValue == null)
                 {
-                    var propInfo = propertyValue.GetType().GetRuntimeProperty(propertyPathPart);
-                    if (propInfo == null)
-                        throw new MissingMemberException($"Unable to find {EventArgsParameterPath}");
-
-                    propertyValue = propInfo.GetValue(propertyValue);
-                    if (propertyValue == null)
-                    {
-                        break;
-                    }
+                    break;
                 }
-                parameter = propertyValue;
             }
+            parameter = propertyValue;
+        }
 
-            if (parameter == null && eventArgs != null && eventArgs != EventArgs.Empty && EventArgsConverter != null)
-            {
-                parameter = EventArgsConverter.Convert(eventArgs, typeof(object), EventArgsConverterParameter,
-                    CultureInfo.CurrentUICulture);
-            }
+        if (parameter == null && eventArgs != null && eventArgs != EventArgs.Empty && EventArgsConverter != null)
+        {
+            parameter = EventArgsConverter.Convert(eventArgs, typeof(object), EventArgsConverterParameter,
+                CultureInfo.CurrentUICulture);
+        }
 
-            if (Command.CanExecute(parameter))
-            {
-                Command.Execute(parameter);
-            }
+        if (Command.CanExecute(parameter))
+        {
+            Command.Execute(parameter);
         }
     }
 }

--- a/src/Prism.Maui/Behaviors/IPageBehaviorFactory.cs
+++ b/src/Prism.Maui/Behaviors/IPageBehaviorFactory.cs
@@ -1,17 +1,14 @@
-﻿using Microsoft.Maui.Controls;
+﻿namespace Prism.Behaviors;
 
-namespace Prism.Behaviors
+/// <summary>
+/// Applies behaviors to the Microsoft.Maui.Controls.Page's when they are created during navigation.
+/// </summary>
+public interface IPageBehaviorFactory
 {
     /// <summary>
-    /// Applies behaviors to the Microsoft.Maui.Controls.Page's when they are created during navigation.
+    /// Applies behaviors to a page based on the page type.
     /// </summary>
-    public interface IPageBehaviorFactory
-    {
-        /// <summary>
-        /// Applies behaviors to a page based on the page type.
-        /// </summary>
-        /// <param name="page">The page to apply the behaviors</param>
-        /// <remarks>The PageLifeCycleAwareBehavior is applied to all pages</remarks>
-        void ApplyPageBehaviors(Page page);
-    }
+    /// <param name="page">The page to apply the behaviors</param>
+    /// <remarks>The PageLifeCycleAwareBehavior is applied to all pages</remarks>
+    void ApplyPageBehaviors(Page page);
 }

--- a/src/Prism.Maui/Behaviors/MultiPageActiveAwareBehavior.cs
+++ b/src/Prism.Maui/Behaviors/MultiPageActiveAwareBehavior.cs
@@ -1,77 +1,75 @@
-﻿using Microsoft.Maui.Controls;
-using Prism.Common;
+﻿using Prism.Common;
 
-namespace Prism.Behaviors
+namespace Prism.Behaviors;
+
+public class MultiPageActiveAwareBehavior<T> : BehaviorBase<MultiPage<T>> where T : Page
 {
-    public class MultiPageActiveAwareBehavior<T> : BehaviorBase<MultiPage<T>> where T : Page
+    protected T _lastSelectedPage;
+
+    /// <inheritDoc/>
+    protected override void OnAttachedTo(MultiPage<T> bindable)
     {
-        protected T _lastSelectedPage;
+        bindable.CurrentPageChanged += CurrentPageChangedHandler;
+        bindable.Appearing += RootPageAppearingHandler;
+        bindable.Disappearing += RootPageDisappearingHandler;
+        base.OnAttachedTo(bindable);
+    }
 
-        /// <inheritDoc/>
-        protected override void OnAttachedTo(MultiPage<T> bindable)
-        {
-            bindable.CurrentPageChanged += CurrentPageChangedHandler;
-            bindable.Appearing += RootPageAppearingHandler;
-            bindable.Disappearing += RootPageDisappearingHandler;
-            base.OnAttachedTo(bindable);
-        }
+    /// <inheritDoc/>
+    protected override void OnDetachingFrom(MultiPage<T> bindable)
+    {
+        bindable.CurrentPageChanged -= CurrentPageChangedHandler;
+        bindable.Appearing -= RootPageAppearingHandler;
+        bindable.Disappearing -= RootPageDisappearingHandler;
+        base.OnDetachingFrom(bindable);
+    }
 
-        /// <inheritDoc/>
-        protected override void OnDetachingFrom(MultiPage<T> bindable)
-        {
-            bindable.CurrentPageChanged -= CurrentPageChangedHandler;
-            bindable.Appearing -= RootPageAppearingHandler;
-            bindable.Disappearing -= RootPageDisappearingHandler;
-            base.OnDetachingFrom(bindable);
-        }
-
-        /// <summary>
-        /// Event Handler for the MultiPage CurrentPageChanged event
-        /// </summary>
-        /// <param name="sender">The MultiPage</param>
-        /// <param name="e">Event Args</param>
-        protected void CurrentPageChangedHandler(object sender, EventArgs e)
-        {
-            if (_lastSelectedPage == null)
-                _lastSelectedPage = AssociatedObject.CurrentPage;
-
-            //inactive 
-            SetIsActive(_lastSelectedPage, false);
-
+    /// <summary>
+    /// Event Handler for the MultiPage CurrentPageChanged event
+    /// </summary>
+    /// <param name="sender">The MultiPage</param>
+    /// <param name="e">Event Args</param>
+    protected void CurrentPageChangedHandler(object sender, EventArgs e)
+    {
+        if (_lastSelectedPage == null)
             _lastSelectedPage = AssociatedObject.CurrentPage;
 
-            //active
-            SetIsActive(_lastSelectedPage, true);
-        }
+        //inactive 
+        SetIsActive(_lastSelectedPage, false);
 
-        /// <summary>
-        /// Event Handler for the MultiPage Appearing event
-        /// </summary>
-        /// <param name="sender">The MultiPage Appearing</param>
-        /// <param name="e">Event Args</param>
-        protected void RootPageAppearingHandler(object sender, EventArgs e)
-        {
-            if (_lastSelectedPage == null)
-                _lastSelectedPage = AssociatedObject.CurrentPage;
+        _lastSelectedPage = AssociatedObject.CurrentPage;
 
-            SetIsActive(_lastSelectedPage, true);
-        }
+        //active
+        SetIsActive(_lastSelectedPage, true);
+    }
 
-        /// <summary>
-        /// Event Handler for the MultiPage Disappearing event
-        /// </summary>
-        /// <param name="sender">The MultiPage Disappearing</param>
-        /// <param name="e">Event Args</param>
-        protected void RootPageDisappearingHandler(object sender, EventArgs e)
-        {
-            SetIsActive(_lastSelectedPage, false);
-        }
+    /// <summary>
+    /// Event Handler for the MultiPage Appearing event
+    /// </summary>
+    /// <param name="sender">The MultiPage Appearing</param>
+    /// <param name="e">Event Args</param>
+    protected void RootPageAppearingHandler(object sender, EventArgs e)
+    {
+        if (_lastSelectedPage == null)
+            _lastSelectedPage = AssociatedObject.CurrentPage;
 
-        private static void SetIsActive(object view, bool isActive)
-        {
-            var pageToSetIsActive = view is NavigationPage page ? page.CurrentPage : view;
+        SetIsActive(_lastSelectedPage, true);
+    }
 
-            PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(pageToSetIsActive, activeAware => activeAware.IsActive = isActive);
-        }
+    /// <summary>
+    /// Event Handler for the MultiPage Disappearing event
+    /// </summary>
+    /// <param name="sender">The MultiPage Disappearing</param>
+    /// <param name="e">Event Args</param>
+    protected void RootPageDisappearingHandler(object sender, EventArgs e)
+    {
+        SetIsActive(_lastSelectedPage, false);
+    }
+
+    private static void SetIsActive(object view, bool isActive)
+    {
+        var pageToSetIsActive = view is NavigationPage page ? page.CurrentPage : view;
+
+        PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(pageToSetIsActive, activeAware => activeAware.IsActive = isActive);
     }
 }

--- a/src/Prism.Maui/Behaviors/NavigationPageActiveAwareBehavior.cs
+++ b/src/Prism.Maui/Behaviors/NavigationPageActiveAwareBehavior.cs
@@ -1,40 +1,38 @@
 ﻿using System.ComponentModel;
-using Microsoft.Maui.Controls;
 using Prism.Common;
 using PropertyChangingEventArgs = Microsoft.Maui.Controls.PropertyChangingEventArgs;
 
-namespace Prism.Behaviors
+namespace Prism.Behaviors;
+
+public class NavigationPageActiveAwareBehavior : BehaviorBase<NavigationPage>
 {
-    public class NavigationPageActiveAwareBehavior : BehaviorBase<NavigationPage>
+    protected override void OnAttachedTo(NavigationPage bindable)
     {
-        protected override void OnAttachedTo(NavigationPage bindable)
-        {
-            bindable.PropertyChanging += NavigationPage_PropertyChanging;
-            bindable.PropertyChanged += NavigationPage_PropertyChanged;
-            base.OnAttachedTo(bindable);
-        }
+        bindable.PropertyChanging += NavigationPage_PropertyChanging;
+        bindable.PropertyChanged += NavigationPage_PropertyChanged;
+        base.OnAttachedTo(bindable);
+    }
 
-        protected override void OnDetachingFrom(NavigationPage bindable)
-        {
-            bindable.PropertyChanging -= NavigationPage_PropertyChanging;
-            bindable.PropertyChanged -= NavigationPage_PropertyChanged;
-            base.OnDetachingFrom(bindable);
-        }
+    protected override void OnDetachingFrom(NavigationPage bindable)
+    {
+        bindable.PropertyChanging -= NavigationPage_PropertyChanging;
+        bindable.PropertyChanged -= NavigationPage_PropertyChanged;
+        base.OnDetachingFrom(bindable);
+    }
 
-        private void NavigationPage_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    private void NavigationPage_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == "CurrentPage")
         {
-            if (e.PropertyName == "CurrentPage")
-            {
-                PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(AssociatedObject.CurrentPage, (obj) => obj.IsActive = true);
-            }
+            PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(AssociatedObject.CurrentPage, (obj) => obj.IsActive = true);
         }
+    }
 
-        private void NavigationPage_PropertyChanging(object sender, PropertyChangingEventArgs e)
+    private void NavigationPage_PropertyChanging(object sender, PropertyChangingEventArgs e)
+    {
+        if (e.PropertyName == "CurrentPage")
         {
-            if (e.PropertyName == "CurrentPage")
-            {
-                PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(AssociatedObject.CurrentPage, (obj) => obj.IsActive = false);
-            }
+            PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(AssociatedObject.CurrentPage, (obj) => obj.IsActive = false);
         }
     }
 }

--- a/src/Prism.Maui/Behaviors/NavigationPageSystemGoBackBehavior.cs
+++ b/src/Prism.Maui/Behaviors/NavigationPageSystemGoBackBehavior.cs
@@ -1,29 +1,27 @@
-﻿using Microsoft.Maui.Controls;
-using Prism.Common;
+﻿using Prism.Common;
 using Prism.Navigation;
 
-namespace Prism.Behaviors
+namespace Prism.Behaviors;
+
+public class NavigationPageSystemGoBackBehavior : BehaviorBase<NavigationPage>
 {
-    public class NavigationPageSystemGoBackBehavior : BehaviorBase<NavigationPage>
+    protected override void OnAttachedTo(NavigationPage bindable)
     {
-        protected override void OnAttachedTo(NavigationPage bindable)
-        {
-            bindable.Popped += NavigationPage_Popped;
-            base.OnAttachedTo(bindable);
-        }
+        bindable.Popped += NavigationPage_Popped;
+        base.OnAttachedTo(bindable);
+    }
 
-        protected override void OnDetachingFrom(NavigationPage bindable)
-        {
-            bindable.Popped -= NavigationPage_Popped;
-            base.OnDetachingFrom(bindable);
-        }
+    protected override void OnDetachingFrom(NavigationPage bindable)
+    {
+        bindable.Popped -= NavigationPage_Popped;
+        base.OnDetachingFrom(bindable);
+    }
 
-        private void NavigationPage_Popped(object sender, NavigationEventArgs e)
+    private void NavigationPage_Popped(object sender, NavigationEventArgs e)
+    {
+        if (PageNavigationService.NavigationSource == PageNavigationSource.Device)
         {
-            if (PageNavigationService.NavigationSource == PageNavigationSource.Device)
-            {
-                PageUtilities.HandleSystemGoBack(e.Page, AssociatedObject.CurrentPage);
-            }
+            PageUtilities.HandleSystemGoBack(e.Page, AssociatedObject.CurrentPage);
         }
     }
 }

--- a/src/Prism.Maui/Behaviors/PageBehaviorFactory.cs
+++ b/src/Prism.Maui/Behaviors/PageBehaviorFactory.cs
@@ -1,84 +1,83 @@
 ﻿using Microsoft.Maui.Controls;
 
-namespace Prism.Behaviors
+namespace Prism.Behaviors;
+
+/// <summary>
+/// Applies behaviors to the Microsoft.Maui.Controls.Page's when they are created during navigation.
+/// </summary>
+public class PageBehaviorFactory : IPageBehaviorFactory
 {
     /// <summary>
-    /// Applies behaviors to the Microsoft.Maui.Controls.Page's when they are created during navigation.
+    /// Applies behaviors to a <see cref="ContentPage" />.
     /// </summary>
-    public class PageBehaviorFactory : IPageBehaviorFactory
+    /// <param name="page">The ContentPage to apply the behaviors</param>
+    protected virtual void ApplyContentPageBehaviors(ContentPage page)
     {
-        /// <summary>
-        /// Applies behaviors to a <see cref="ContentPage" />.
-        /// </summary>
-        /// <param name="page">The ContentPage to apply the behaviors</param>
-        protected virtual void ApplyContentPageBehaviors(ContentPage page)
-        {
 
+    }
+
+    /// <summary>
+    /// Applies behaviors to a <see cref="FlyoutPage" />
+    /// </summary>
+    /// <param name="page">The <see cref="FlyoutPage" /> to apply the behaviors.</param>
+    protected virtual void ApplyFlyoutPageBehaviors(FlyoutPage page)
+    {
+
+    }
+
+    /// <summary>
+    /// Applies behaviors to a <see cref="NavigationPage" />.
+    /// </summary>
+    /// <param name="page">The <see cref="NavigationPage" /> to apply the behaviors</param>
+    /// <remarks>The NavigationPageSystemGoBackBehavior and NavigationPageActiveAwareBehavior are applied by default</remarks>
+    protected virtual void ApplyNavigationPageBehaviors(NavigationPage page)
+    {
+        page.Behaviors.Add(new NavigationPageSystemGoBackBehavior());
+        page.Behaviors.Add(new NavigationPageActiveAwareBehavior());
+    }
+
+    /// <summary>
+    /// Applies behaviors to a page based on the <see cref="Page" /> type.
+    /// </summary>
+    /// <param name="page">The <see cref="Page" /> to apply the behaviors.</param>
+    /// <remarks>
+    /// There is no need to call base.ApplyPageBehaviors when overriding.
+    /// All Prism behaviors have already been applied.
+    /// </remarks>
+    protected virtual void ApplyPageBehaviors(Page page)
+    {
+    }
+
+    void IPageBehaviorFactory.ApplyPageBehaviors(Page page)
+    {
+        switch (page)
+        {
+            case ContentPage contentPage:
+                ApplyContentPageBehaviors(contentPage);
+                break;
+            case NavigationPage navPage:
+                ApplyNavigationPageBehaviors(navPage);
+                break;
+            case FlyoutPage flyoutPage:
+                ApplyFlyoutPageBehaviors(flyoutPage);
+                break;
+            case TabbedPage tabbedPage:
+                ApplyTabbedPageBehaviors(tabbedPage);
+                break;
         }
 
-        /// <summary>
-        /// Applies behaviors to a <see cref="FlyoutPage" />
-        /// </summary>
-        /// <param name="page">The <see cref="FlyoutPage" /> to apply the behaviors.</param>
-        protected virtual void ApplyFlyoutPageBehaviors(FlyoutPage page)
-        {
+        page.Behaviors.Add(new PageLifeCycleAwareBehavior());
+        page.Behaviors.Add(new PageScopeBehavior());
+        ApplyPageBehaviors(page);
+    }
 
-        }
-
-        /// <summary>
-        /// Applies behaviors to a <see cref="NavigationPage" />.
-        /// </summary>
-        /// <param name="page">The <see cref="NavigationPage" /> to apply the behaviors</param>
-        /// <remarks>The NavigationPageSystemGoBackBehavior and NavigationPageActiveAwareBehavior are applied by default</remarks>
-        protected virtual void ApplyNavigationPageBehaviors(NavigationPage page)
-        {
-            page.Behaviors.Add(new NavigationPageSystemGoBackBehavior());
-            page.Behaviors.Add(new NavigationPageActiveAwareBehavior());
-        }
-
-        /// <summary>
-        /// Applies behaviors to a page based on the <see cref="Page" /> type.
-        /// </summary>
-        /// <param name="page">The <see cref="Page" /> to apply the behaviors.</param>
-        /// <remarks>
-        /// There is no need to call base.ApplyPageBehaviors when overriding.
-        /// All Prism behaviors have already been applied.
-        /// </remarks>
-        protected virtual void ApplyPageBehaviors(Page page)
-        {
-        }
-
-        void IPageBehaviorFactory.ApplyPageBehaviors(Page page)
-        {
-            switch (page)
-            {
-                case ContentPage contentPage:
-                    ApplyContentPageBehaviors(contentPage);
-                    break;
-                case NavigationPage navPage:
-                    ApplyNavigationPageBehaviors(navPage);
-                    break;
-                case FlyoutPage flyoutPage:
-                    ApplyFlyoutPageBehaviors(flyoutPage);
-                    break;
-                case TabbedPage tabbedPage:
-                    ApplyTabbedPageBehaviors(tabbedPage);
-                    break;
-            }
-
-            page.Behaviors.Add(new PageLifeCycleAwareBehavior());
-            page.Behaviors.Add(new PageScopeBehavior());
-            ApplyPageBehaviors(page);
-        }
-
-        /// <summary>
-        /// Applies behaviors to a TabbedPage.
-        /// </summary>
-        /// <param name="page">The TabbedPage to apply the behaviors</param>
-        /// <remarks>The TabbedPageActiveAwareBehavior is added by default</remarks>
-        protected virtual void ApplyTabbedPageBehaviors(TabbedPage page)
-        {
-            page.Behaviors.Add(new TabbedPageActiveAwareBehavior());
-        }
+    /// <summary>
+    /// Applies behaviors to a TabbedPage.
+    /// </summary>
+    /// <param name="page">The TabbedPage to apply the behaviors</param>
+    /// <remarks>The TabbedPageActiveAwareBehavior is added by default</remarks>
+    protected virtual void ApplyTabbedPageBehaviors(TabbedPage page)
+    {
+        page.Behaviors.Add(new TabbedPageActiveAwareBehavior());
     }
 }

--- a/src/Prism.Maui/Behaviors/PageLifeCycleAwareBehavior.cs
+++ b/src/Prism.Maui/Behaviors/PageLifeCycleAwareBehavior.cs
@@ -1,33 +1,31 @@
-﻿using Microsoft.Maui.Controls;
-using Prism.AppModel;
+﻿using Prism.AppModel;
 using Prism.Common;
 
-namespace Prism.Behaviors
+namespace Prism.Behaviors;
+
+public class PageLifeCycleAwareBehavior : BehaviorBase<Page>
 {
-    public class PageLifeCycleAwareBehavior : BehaviorBase<Page>
+    protected override void OnAttachedTo(Page bindable)
     {
-        protected override void OnAttachedTo(Page bindable)
-        {
-            base.OnAttachedTo(bindable);
-            bindable.Appearing += OnAppearing;
-            bindable.Disappearing += OnDisappearing;
-        }
+        base.OnAttachedTo(bindable);
+        bindable.Appearing += OnAppearing;
+        bindable.Disappearing += OnDisappearing;
+    }
 
-        protected override void OnDetachingFrom(Page bindable)
-        {
-            base.OnDetachingFrom(bindable);
-            bindable.Appearing -= OnAppearing;
-            bindable.Disappearing -= OnDisappearing;
-        }
+    protected override void OnDetachingFrom(Page bindable)
+    {
+        base.OnDetachingFrom(bindable);
+        bindable.Appearing -= OnAppearing;
+        bindable.Disappearing -= OnDisappearing;
+    }
 
-        private void OnAppearing(object sender, EventArgs e)
-        {
-            PageUtilities.InvokeViewAndViewModelAction<IPageLifecycleAware>(AssociatedObject, aware => aware.OnAppearing());
-        }
+    private void OnAppearing(object sender, EventArgs e)
+    {
+        PageUtilities.InvokeViewAndViewModelAction<IPageLifecycleAware>(AssociatedObject, aware => aware.OnAppearing());
+    }
 
-        private void OnDisappearing(object sender, EventArgs e)
-        {
-            PageUtilities.InvokeViewAndViewModelAction<IPageLifecycleAware>(AssociatedObject, aware => aware.OnDisappearing());
-        }
+    private void OnDisappearing(object sender, EventArgs e)
+    {
+        PageUtilities.InvokeViewAndViewModelAction<IPageLifecycleAware>(AssociatedObject, aware => aware.OnDisappearing());
     }
 }

--- a/src/Prism.Maui/Behaviors/PageScopeBehavior.cs
+++ b/src/Prism.Maui/Behaviors/PageScopeBehavior.cs
@@ -1,24 +1,21 @@
-﻿using Microsoft.Maui.Controls;
+﻿namespace Prism.Behaviors;
 
-namespace Prism.Behaviors
+/// <summary>
+/// Controls the Page container Scope
+/// </summary>
+public sealed class PageScopeBehavior : BehaviorBase<Page>
 {
-    /// <summary>
-    /// Controls the Page container Scope
-    /// </summary>
-    public sealed class PageScopeBehavior : BehaviorBase<Page>
+    protected override void OnAttachedTo(Page page)
     {
-        protected override void OnAttachedTo(Page page)
-        {
-            base.OnAttachedTo(page);
-            // Ensure the scope gets created and NavigationService is created
-            Navigation.Xaml.Navigation.GetNavigationService(page);
-        }
+        base.OnAttachedTo(page);
+        // Ensure the scope gets created and NavigationService is created
+        Navigation.Xaml.Navigation.GetNavigationService(page);
+    }
 
-        protected override void OnDetachingFrom(Page page)
-        {
-            base.OnDetachingFrom(page);
-            // This forces the Attached Property to get cleaned up.
-            page.SetValue(Navigation.Xaml.Navigation.NavigationScopeProperty, null);
-        }
+    protected override void OnDetachingFrom(Page page)
+    {
+        base.OnDetachingFrom(page);
+        // This forces the Attached Property to get cleaned up.
+        page.SetValue(Navigation.Xaml.Navigation.NavigationScopeProperty, null);
     }
 }

--- a/src/Prism.Maui/Behaviors/TabbedPageActiveAwareBehavior.cs
+++ b/src/Prism.Maui/Behaviors/TabbedPageActiveAwareBehavior.cs
@@ -1,8 +1,5 @@
-﻿using Microsoft.Maui.Controls;
+﻿namespace Prism.Behaviors;
 
-namespace Prism.Behaviors
+public class TabbedPageActiveAwareBehavior : MultiPageActiveAwareBehavior<Page>
 {
-    public class TabbedPageActiveAwareBehavior : MultiPageActiveAwareBehavior<Page>
-    {
-    }
 }

--- a/src/Prism.Maui/Common/PageUtilities.cs
+++ b/src/Prism.Maui/Common/PageUtilities.cs
@@ -3,293 +3,292 @@ using System.Reflection;
 using Prism.Navigation;
 using NavigationMode = Prism.Navigation.NavigationMode;
 
-namespace Prism.Common
+namespace Prism.Common;
+
+// TODO: Refactor from Static class to interface
+public static class PageUtilities
 {
-    // TODO: Refactor from Static class to interface
-    public static class PageUtilities
+    public static void InvokeViewAndViewModelAction<T>(object view, Action<T> action) where T : class
     {
-        public static void InvokeViewAndViewModelAction<T>(object view, Action<T> action) where T : class
+        if (view is T viewAsT)
         {
-            if (view is T viewAsT)
-            {
-                action(viewAsT);
-            }
-
-            if (view is BindableObject element && element.BindingContext is T viewModelAsT)
-            {
-                action(viewModelAsT);
-            }
+            action(viewAsT);
         }
 
-        public static async Task InvokeViewAndViewModelActionAsync<T>(object view, Func<T, Task> action) where T : class
+        if (view is BindableObject element && element.BindingContext is T viewModelAsT)
         {
-            if (view is T viewAsT)
-            {
-                await action(viewAsT);
-            }
+            action(viewModelAsT);
+        }
+    }
 
-            if (view is BindableObject element && element.BindingContext is T viewModelAsT)
-            {
-                await action(viewModelAsT);
-            }
+    public static async Task InvokeViewAndViewModelActionAsync<T>(object view, Func<T, Task> action) where T : class
+    {
+        if (view is T viewAsT)
+        {
+            await action(viewAsT);
         }
 
-        public static void DestroyPage(IView view)
+        if (view is BindableObject element && element.BindingContext is T viewModelAsT)
         {
-            try
+            await action(viewModelAsT);
+        }
+    }
+
+    public static void DestroyPage(IView view)
+    {
+        try
+        {
+            DestroyChildren(view);
+
+            InvokeViewAndViewModelAction<IDestructible>(view, v => v.Destroy());
+
+            if(view is Page page)
             {
-                DestroyChildren(view);
+                page.Behaviors?.Clear();
+                page.BindingContext = null;
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Cannot destroy {view}.", ex);
+        }
+    }
 
-                InvokeViewAndViewModelAction<IDestructible>(view, v => v.Destroy());
-
-                if(view is Page page)
+    private static void DestroyChildren(IView page)
+    {
+        switch (page)
+        {
+            case FlyoutPage flyout:
+                DestroyPage(flyout.Flyout);
+                DestroyPage(flyout.Detail);
+                break;
+            case TabbedPage tabbedPage:
+                foreach (var item in tabbedPage.Children.Reverse())
                 {
-                    page.Behaviors?.Clear();
-                    page.BindingContext = null;
+                    DestroyPage(item);
                 }
-            }
-            catch (Exception ex)
-            {
-                throw new Exception($"Cannot destroy {view}.", ex);
-            }
+                break;
+            case NavigationPage navigationPage:
+                foreach (var item in navigationPage.Navigation.NavigationStack.Reverse())
+                {
+                    DestroyPage(item);
+                }
+                break;
+        }
+    }
+
+    public static void DestroyWithModalStack(Page page, IList<Page> modalStack)
+    {
+        foreach (var childPage in modalStack.Reverse())
+        {
+            DestroyPage(childPage);
+        }
+        DestroyPage(page);
+    }
+
+
+    public static Task<bool> CanNavigateAsync(object page, INavigationParameters parameters)
+    {
+        if (page is IConfirmNavigationAsync confirmNavigationItem)
+            return confirmNavigationItem.CanNavigateAsync(parameters);
+
+        if (page is BindableObject bindableObject)
+        {
+            if (bindableObject.BindingContext is IConfirmNavigationAsync confirmNavigationBindingContext)
+                return confirmNavigationBindingContext.CanNavigateAsync(parameters);
         }
 
-        private static void DestroyChildren(IView page)
+        return Task.FromResult(CanNavigate(page, parameters));
+    }
+
+    public static bool CanNavigate(object page, INavigationParameters parameters)
+    {
+        if (page is IConfirmNavigation confirmNavigationItem)
+            return confirmNavigationItem.CanNavigate(parameters);
+
+        if (page is BindableObject bindableObject)
         {
-            switch (page)
-            {
-                case FlyoutPage flyout:
-                    DestroyPage(flyout.Flyout);
-                    DestroyPage(flyout.Detail);
-                    break;
-                case TabbedPage tabbedPage:
-                    foreach (var item in tabbedPage.Children.Reverse())
-                    {
-                        DestroyPage(item);
-                    }
-                    break;
-                case NavigationPage navigationPage:
-                    foreach (var item in navigationPage.Navigation.NavigationStack.Reverse())
-                    {
-                        DestroyPage(item);
-                    }
-                    break;
-            }
+            if (bindableObject.BindingContext is IConfirmNavigation confirmNavigationBindingContext)
+                return confirmNavigationBindingContext.CanNavigate(parameters);
         }
 
-        public static void DestroyWithModalStack(Page page, IList<Page> modalStack)
+        return true;
+    }
+
+    public static void OnNavigatedFrom(object page, INavigationParameters parameters)
+    {
+        if (page != null)
+            InvokeViewAndViewModelAction<INavigatedAware>(page, v => v.OnNavigatedFrom(parameters));
+    }
+
+    public static async Task OnInitializedAsync(object page, INavigationParameters parameters)
+    {
+        if (page is null) return;
+
+        InvokeViewAndViewModelAction<IInitialize>(page, v => v.Initialize(parameters));
+        await InvokeViewAndViewModelActionAsync<IInitializeAsync>(page, async v => await v.InitializeAsync(parameters));
+    }
+
+    private static bool HasKey(this IEnumerable<KeyValuePair<string, object>> parameters, string name, out string key)
+    {
+        key = parameters.Select(x => x.Key).FirstOrDefault(k => k.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+        return !string.IsNullOrEmpty(key);
+    }
+
+    public static void OnNavigatedTo(object page, INavigationParameters parameters)
+    {
+        if (page != null)
+            InvokeViewAndViewModelAction<INavigatedAware>(page, v => v.OnNavigatedTo(parameters));
+    }
+
+    public static Page GetOnNavigatedToTarget(Page page, IView mainPage, bool useModalNavigation)
+    {
+        Page target;
+        if (useModalNavigation)
         {
-            foreach (var childPage in modalStack.Reverse())
-            {
-                DestroyPage(childPage);
-            }
-            DestroyPage(page);
+            var previousPage = GetPreviousPage(page, page.Navigation.ModalStack);
+
+            //MainPage is not included in the navigation stack, so if we can't find the previous page above
+            //let's assume they are going back to the MainPage
+            target = GetOnNavigatedToTargetFromChild(previousPage ?? mainPage);
         }
-
-
-        public static Task<bool> CanNavigateAsync(object page, INavigationParameters parameters)
+        else
         {
-            if (page is IConfirmNavigationAsync confirmNavigationItem)
-                return confirmNavigationItem.CanNavigateAsync(parameters);
-
-            if (page is BindableObject bindableObject)
-            {
-                if (bindableObject.BindingContext is IConfirmNavigationAsync confirmNavigationBindingContext)
-                    return confirmNavigationBindingContext.CanNavigateAsync(parameters);
-            }
-
-            return Task.FromResult(CanNavigate(page, parameters));
-        }
-
-        public static bool CanNavigate(object page, INavigationParameters parameters)
-        {
-            if (page is IConfirmNavigation confirmNavigationItem)
-                return confirmNavigationItem.CanNavigate(parameters);
-
-            if (page is BindableObject bindableObject)
-            {
-                if (bindableObject.BindingContext is IConfirmNavigation confirmNavigationBindingContext)
-                    return confirmNavigationBindingContext.CanNavigate(parameters);
-            }
-
-            return true;
-        }
-
-        public static void OnNavigatedFrom(object page, INavigationParameters parameters)
-        {
-            if (page != null)
-                InvokeViewAndViewModelAction<INavigatedAware>(page, v => v.OnNavigatedFrom(parameters));
-        }
-
-        public static async Task OnInitializedAsync(object page, INavigationParameters parameters)
-        {
-            if (page is null) return;
-
-            InvokeViewAndViewModelAction<IInitialize>(page, v => v.Initialize(parameters));
-            await InvokeViewAndViewModelActionAsync<IInitializeAsync>(page, async v => await v.InitializeAsync(parameters));
-        }
-
-        private static bool HasKey(this IEnumerable<KeyValuePair<string, object>> parameters, string name, out string key)
-        {
-            key = parameters.Select(x => x.Key).FirstOrDefault(k => k.Equals(name, StringComparison.InvariantCultureIgnoreCase));
-            return !string.IsNullOrEmpty(key);
-        }
-
-        public static void OnNavigatedTo(object page, INavigationParameters parameters)
-        {
-            if (page != null)
-                InvokeViewAndViewModelAction<INavigatedAware>(page, v => v.OnNavigatedTo(parameters));
-        }
-
-        public static Page GetOnNavigatedToTarget(Page page, IView mainPage, bool useModalNavigation)
-        {
-            Page target;
-            if (useModalNavigation)
-            {
-                var previousPage = GetPreviousPage(page, page.Navigation.ModalStack);
-
-                //MainPage is not included in the navigation stack, so if we can't find the previous page above
-                //let's assume they are going back to the MainPage
-                target = GetOnNavigatedToTargetFromChild(previousPage ?? mainPage);
-            }
+            target = GetPreviousPage(page, page.Navigation.NavigationStack);
+            if (target != null)
+                target = GetOnNavigatedToTargetFromChild(target);
             else
+                target = GetOnNavigatedToTarget(page, mainPage, true);
+        }
+
+        return target;
+    }
+
+    public static Page GetOnNavigatedToTargetFromChild(IView target)
+    {
+        Page child = null;
+
+        if (target is FlyoutPage flyout)
+            child = flyout.Detail;
+        else if (target is TabbedPage tabbed)
+            child = tabbed.CurrentPage;
+        else if (target is NavigationPage np)
+            child = np.Navigation.NavigationStack.Last();
+
+        if (child != null)
+            target = GetOnNavigatedToTargetFromChild(child);
+
+        if (target is Page page)
+            return page;
+
+        return null;
+    }
+
+    public static Page GetPreviousPage(Page currentPage, System.Collections.Generic.IReadOnlyList<Page> navStack)
+    {
+        Page previousPage = null;
+
+        int currentPageIndex = GetCurrentPageIndex(currentPage, navStack);
+        int previousPageIndex = currentPageIndex - 1;
+        if (navStack.Count >= 0 && previousPageIndex >= 0)
+            previousPage = navStack[previousPageIndex];
+
+        return previousPage;
+    }
+
+    public static int GetCurrentPageIndex(Page currentPage, System.Collections.Generic.IReadOnlyList<Page> navStack)
+    {
+        int stackCount = navStack.Count;
+        for (int x = 0; x < stackCount; x++)
+        {
+            var view = navStack[x];
+            if (view == currentPage)
+                return x;
+        }
+
+        return stackCount - 1;
+    }
+
+    public static Page GetCurrentPage(Page mainPage) =>
+        _getCurrentPage(mainPage);
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void SetCurrentPageDelegate(Func<Page, Page> getCurrentPageDelegate) =>
+        _getCurrentPage = getCurrentPageDelegate;
+
+    private static Func<Page, Page> _getCurrentPage = mainPage =>
+    {
+        var page = mainPage;
+
+        var lastModal = page.Navigation.ModalStack.LastOrDefault();
+        if (lastModal != null)
+            page = lastModal;
+
+        return GetOnNavigatedToTargetFromChild(page);
+    };
+
+    public static async Task HandleNavigationPageGoBack(NavigationPage navigationPage)
+    {
+        var previousPage = navigationPage.CurrentPage;
+        var parameters = new NavigationParameters();
+        parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
+        if (!CanNavigate(previousPage, parameters) ||
+            !await CanNavigateAsync(previousPage, parameters))
+            return;
+
+        PageNavigationService.NavigationSource = PageNavigationSource.NavigationService;
+        await navigationPage.PopAsync();
+        PageNavigationService.NavigationSource = PageNavigationSource.Device;
+        OnNavigatedFrom(previousPage, parameters);
+        OnNavigatedTo(navigationPage.CurrentPage, parameters);
+        DestroyPage(previousPage);
+    }
+
+    public static void HandleSystemGoBack(IView previousPage, IView currentPage)
+    {
+        var parameters = new NavigationParameters();
+        parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
+        OnNavigatedFrom(previousPage, parameters);
+        OnNavigatedTo(GetOnNavigatedToTargetFromChild(currentPage), parameters);
+        DestroyPage(previousPage);
+    }
+
+    internal static bool HasDirectNavigationPageParent(Page page)
+    {
+        return page?.Parent != null && page?.Parent is NavigationPage;
+    }
+
+    internal static bool HasNavigationPageParent(Page page) =>
+        HasNavigationPageParent(page, out var _);
+
+    internal static bool HasNavigationPageParent(Page page, out NavigationPage navigationPage)
+    {
+        if (page?.Parent != null)
+        {
+            if (page.Parent is NavigationPage navParent)
             {
-                target = GetPreviousPage(page, page.Navigation.NavigationStack);
-                if (target != null)
-                    target = GetOnNavigatedToTargetFromChild(target);
-                else
-                    target = GetOnNavigatedToTarget(page, mainPage, true);
+                navigationPage = navParent;
+                return true;
             }
-
-            return target;
-        }
-
-        public static Page GetOnNavigatedToTargetFromChild(IView target)
-        {
-            Page child = null;
-
-            if (target is FlyoutPage flyout)
-                child = flyout.Detail;
-            else if (target is TabbedPage tabbed)
-                child = tabbed.CurrentPage;
-            else if (target is NavigationPage np)
-                child = np.Navigation.NavigationStack.Last();
-
-            if (child != null)
-                target = GetOnNavigatedToTargetFromChild(child);
-
-            if (target is Page page)
-                return page;
-
-            return null;
-        }
-
-        public static Page GetPreviousPage(Page currentPage, System.Collections.Generic.IReadOnlyList<Page> navStack)
-        {
-            Page previousPage = null;
-
-            int currentPageIndex = GetCurrentPageIndex(currentPage, navStack);
-            int previousPageIndex = currentPageIndex - 1;
-            if (navStack.Count >= 0 && previousPageIndex >= 0)
-                previousPage = navStack[previousPageIndex];
-
-            return previousPage;
-        }
-
-        public static int GetCurrentPageIndex(Page currentPage, System.Collections.Generic.IReadOnlyList<Page> navStack)
-        {
-            int stackCount = navStack.Count;
-            for (int x = 0; x < stackCount; x++)
+            else if ((page.Parent is TabbedPage) && page.Parent?.Parent is NavigationPage navigationParent)
             {
-                var view = navStack[x];
-                if (view == currentPage)
-                    return x;
+                navigationPage = navigationParent;
+                return true;
             }
-
-            return stackCount - 1;
         }
 
-        public static Page GetCurrentPage(Page mainPage) =>
-            _getCurrentPage(mainPage);
+        navigationPage = null;
+        return false;
+    }
 
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void SetCurrentPageDelegate(Func<Page, Page> getCurrentPageDelegate) =>
-            _getCurrentPage = getCurrentPageDelegate;
-
-        private static Func<Page, Page> _getCurrentPage = mainPage =>
-        {
-            var page = mainPage;
-
-            var lastModal = page.Navigation.ModalStack.LastOrDefault();
-            if (lastModal != null)
-                page = lastModal;
-
-            return GetOnNavigatedToTargetFromChild(page);
-        };
-
-        public static async Task HandleNavigationPageGoBack(NavigationPage navigationPage)
-        {
-            var previousPage = navigationPage.CurrentPage;
-            var parameters = new NavigationParameters();
-            parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
-            if (!CanNavigate(previousPage, parameters) ||
-                !await CanNavigateAsync(previousPage, parameters))
-                return;
-
-            PageNavigationService.NavigationSource = PageNavigationSource.NavigationService;
-            await navigationPage.PopAsync();
-            PageNavigationService.NavigationSource = PageNavigationSource.Device;
-            OnNavigatedFrom(previousPage, parameters);
-            OnNavigatedTo(navigationPage.CurrentPage, parameters);
-            DestroyPage(previousPage);
-        }
-
-        public static void HandleSystemGoBack(IView previousPage, IView currentPage)
-        {
-            var parameters = new NavigationParameters();
-            parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
-            OnNavigatedFrom(previousPage, parameters);
-            OnNavigatedTo(GetOnNavigatedToTargetFromChild(currentPage), parameters);
-            DestroyPage(previousPage);
-        }
-
-        internal static bool HasDirectNavigationPageParent(Page page)
-        {
-            return page?.Parent != null && page?.Parent is NavigationPage;
-        }
-
-        internal static bool HasNavigationPageParent(Page page) =>
-            HasNavigationPageParent(page, out var _);
-
-        internal static bool HasNavigationPageParent(Page page, out NavigationPage navigationPage)
-        {
-            if (page?.Parent != null)
-            {
-                if (page.Parent is NavigationPage navParent)
-                {
-                    navigationPage = navParent;
-                    return true;
-                }
-                else if ((page.Parent is TabbedPage) && page.Parent?.Parent is NavigationPage navigationParent)
-                {
-                    navigationPage = navigationParent;
-                    return true;
-                }
-            }
-
-            navigationPage = null;
+    internal static bool IsSameOrSubclassOf<T>(Type potentialDescendant)
+    {
+        if (potentialDescendant == null)
             return false;
-        }
 
-        internal static bool IsSameOrSubclassOf<T>(Type potentialDescendant)
-        {
-            if (potentialDescendant == null)
-                return false;
+        Type potentialBase = typeof(T);
 
-            Type potentialBase = typeof(T);
-
-            return potentialDescendant.GetTypeInfo().IsSubclassOf(potentialBase)
-                   || potentialDescendant == potentialBase;
-        }
+        return potentialDescendant.GetTypeInfo().IsSubclassOf(potentialBase)
+               || potentialDescendant == potentialBase;
     }
 }

--- a/src/Prism.Maui/Common/UriParsingHelper.cs
+++ b/src/Prism.Maui/Common/UriParsingHelper.cs
@@ -1,126 +1,125 @@
 ﻿using Prism.Navigation;
 using Prism.Services.Dialogs;
 
-namespace Prism.Common
+namespace Prism.Common;
+
+/// <summary>
+/// Helper class for parsing <see cref="Uri"/> instances.
+/// </summary>
+public static class UriParsingHelper
 {
-    /// <summary>
-    /// Helper class for parsing <see cref="Uri"/> instances.
-    /// </summary>
-    public static class UriParsingHelper
+    private static readonly char[] _pathDelimiter = { '/' };
+
+    public static Queue<string> GetUriSegments(Uri uri)
     {
-        private static readonly char[] _pathDelimiter = { '/' };
+        var segmentStack = new Queue<string>();
 
-        public static Queue<string> GetUriSegments(Uri uri)
+        if (!uri.IsAbsoluteUri)
         {
-            var segmentStack = new Queue<string>();
-
-            if (!uri.IsAbsoluteUri)
-            {
-                uri = EnsureAbsolute(uri);
-            }
-
-            string[] segments = uri.PathAndQuery.Split(_pathDelimiter, StringSplitOptions.RemoveEmptyEntries);
-            foreach (var segment in segments)
-            {
-                segmentStack.Enqueue(Uri.UnescapeDataString(segment));
-            }
-
-            return segmentStack;
+            uri = EnsureAbsolute(uri);
         }
 
-        public static string GetSegmentName(string segment)
+        string[] segments = uri.PathAndQuery.Split(_pathDelimiter, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var segment in segments)
         {
-            return segment.Split('?')[0];
+            segmentStack.Enqueue(Uri.UnescapeDataString(segment));
         }
 
-        public static INavigationParameters GetSegmentParameters(string segment)
+        return segmentStack;
+    }
+
+    public static string GetSegmentName(string segment)
+    {
+        return segment.Split('?')[0];
+    }
+
+    public static INavigationParameters GetSegmentParameters(string segment)
+    {
+        string query = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(segment))
         {
-            string query = string.Empty;
-
-            if (string.IsNullOrWhiteSpace(segment))
-            {
-                return new NavigationParameters(query);
-            }
-
-            var indexOfQuery = segment.IndexOf('?');
-            if (indexOfQuery > 0)
-                query = segment[indexOfQuery..];
-
             return new NavigationParameters(query);
         }
 
-        public static INavigationParameters GetSegmentParameters(string uriSegment, INavigationParameters parameters)
+        var indexOfQuery = segment.IndexOf('?');
+        if (indexOfQuery > 0)
+            query = segment[indexOfQuery..];
+
+        return new NavigationParameters(query);
+    }
+
+    public static INavigationParameters GetSegmentParameters(string uriSegment, INavigationParameters parameters)
+    {
+        var navParameters = UriParsingHelper.GetSegmentParameters(uriSegment);
+
+        if (parameters != null)
         {
-            var navParameters = UriParsingHelper.GetSegmentParameters(uriSegment);
-
-            if (parameters != null)
+            foreach (KeyValuePair<string, object> navigationParameter in parameters)
             {
-                foreach (KeyValuePair<string, object> navigationParameter in parameters)
-                {
-                    navParameters.Add(navigationParameter.Key, navigationParameter.Value);
-                }
+                navParameters.Add(navigationParameter.Key, navigationParameter.Value);
             }
-
-            return navParameters;
         }
 
-        public static IDialogParameters GetSegmentDialogParameters(string segment)
+        return navParameters;
+    }
+
+    public static IDialogParameters GetSegmentDialogParameters(string segment)
+    {
+        string query = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(segment))
         {
-            string query = string.Empty;
-
-            if (string.IsNullOrWhiteSpace(segment))
-            {
-                return new DialogParameters(query);
-            }
-
-            var indexOfQuery = segment.IndexOf('?');
-            if (indexOfQuery > 0)
-                query = segment[indexOfQuery..];
-
             return new DialogParameters(query);
         }
 
-        public static IDialogParameters GetSegmentParameters(string uriSegment, IDialogParameters parameters)
+        var indexOfQuery = segment.IndexOf('?');
+        if (indexOfQuery > 0)
+            query = segment[indexOfQuery..];
+
+        return new DialogParameters(query);
+    }
+
+    public static IDialogParameters GetSegmentParameters(string uriSegment, IDialogParameters parameters)
+    {
+        var dialogParameters = GetSegmentDialogParameters(uriSegment);
+
+        if (parameters != null)
         {
-            var dialogParameters = GetSegmentDialogParameters(uriSegment);
-
-            if (parameters != null)
+            foreach (KeyValuePair<string, object> navigationParameter in parameters)
             {
-                foreach (KeyValuePair<string, object> navigationParameter in parameters)
-                {
-                    dialogParameters.Add(navigationParameter.Key, navigationParameter.Value);
-                }
+                dialogParameters.Add(navigationParameter.Key, navigationParameter.Value);
             }
-
-            return dialogParameters;
         }
 
-        public static Uri EnsureAbsolute(Uri uri)
-        {
-            if (uri.IsAbsoluteUri)
-            {
-                return uri;
-            }
+        return dialogParameters;
+    }
 
-            if (!uri.OriginalString.StartsWith("/", StringComparison.Ordinal))
-            {
-                return new Uri("http://localhost/" + uri, UriKind.Absolute);
-            }
+    public static Uri EnsureAbsolute(Uri uri)
+    {
+        if (uri.IsAbsoluteUri)
+        {
+            return uri;
+        }
+
+        if (!uri.OriginalString.StartsWith("/", StringComparison.Ordinal))
+        {
+            return new Uri("http://localhost/" + uri, UriKind.Absolute);
+        }
+        return new Uri("http://localhost" + uri, UriKind.Absolute);
+    }
+
+    public static Uri Parse(string uri)
+    {
+        if (uri == null) throw new ArgumentNullException(nameof(uri));
+
+        if (uri.StartsWith("/", StringComparison.Ordinal))
+        {
             return new Uri("http://localhost" + uri, UriKind.Absolute);
         }
-
-        public static Uri Parse(string uri)
+        else
         {
-            if (uri == null) throw new ArgumentNullException(nameof(uri));
-
-            if (uri.StartsWith("/", StringComparison.Ordinal))
-            {
-                return new Uri("http://localhost" + uri, UriKind.Absolute);
-            }
-            else
-            {
-                return new Uri(uri, UriKind.RelativeOrAbsolute);
-            }
+            return new Uri(uri, UriKind.RelativeOrAbsolute);
         }
     }
 }

--- a/src/Prism.Maui/Extensions/VisualElementExtensions.cs
+++ b/src/Prism.Maui/Extensions/VisualElementExtensions.cs
@@ -1,26 +1,23 @@
-﻿using Microsoft.Maui.Controls;
+﻿namespace Prism.Extensions;
 
-namespace Prism.Extensions
+internal static class VisualElementExtensions
 {
-    internal static class VisualElementExtensions
+    public static bool TryGetParentPage(this VisualElement element, out Page page)
     {
-        public static bool TryGetParentPage(this VisualElement element, out Page page)
-        {
-            page = GetParentPage(element);
-            return page != null;
-        }
+        page = GetParentPage(element);
+        return page != null;
+    }
 
-        private static Page GetParentPage(Element visualElement)
+    private static Page GetParentPage(Element visualElement)
+    {
+        switch (visualElement.Parent)
         {
-            switch (visualElement.Parent)
-            {
-                case Page page:
-                    return page;
-                case null:
-                    return null;
-                default:
-                    return GetParentPage(visualElement.Parent);
-            }
+            case Page page:
+                return page;
+            case null:
+                return null;
+            default:
+                return GetParentPage(visualElement.Parent);
         }
     }
 }

--- a/src/Prism.Maui/ILegacyPrismApplication.cs
+++ b/src/Prism.Maui/ILegacyPrismApplication.cs
@@ -1,4 +1,6 @@
-﻿internal interface ILegacyPrismApplication
+﻿namespace Prism;
+
+internal interface ILegacyPrismApplication
 {
     void OnInitialized();
 }

--- a/src/Prism.Maui/Ioc/IResolverOverridesHelper.cs
+++ b/src/Prism.Maui/Ioc/IResolverOverridesHelper.cs
@@ -1,10 +1,9 @@
-namespace Prism.Ioc
+namespace Prism.Ioc;
+
+/// <summary>
+/// Provides a helper interface for Regions to be able to inject the current Region
+/// </summary>
+public interface IResolverOverridesHelper
 {
-    /// <summary>
-    /// Provides a helper interface for Regions to be able to inject the current Region
-    /// </summary>
-    public interface IResolverOverridesHelper
-    {
-        IEnumerable<(Type Type, object Instance)> GetOverrides();
-    }
+    IEnumerable<(Type Type, object Instance)> GetOverrides();
 }

--- a/src/Prism.Maui/Ioc/IServiceCollectionAware.cs
+++ b/src/Prism.Maui/Ioc/IServiceCollectionAware.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿namespace Prism.Ioc;
 
-namespace Prism.Ioc
+public interface IServiceCollectionAware
 {
-    public interface IServiceCollectionAware
-    {
-        void Populate(IServiceCollection services);
-        IServiceProvider CreateServiceProvider();
-    }
+    void Populate(IServiceCollection services);
+    IServiceProvider CreateServiceProvider();
 }

--- a/src/Prism.Maui/Ioc/NavigationRegistrationExtensions.cs
+++ b/src/Prism.Maui/Ioc/NavigationRegistrationExtensions.cs
@@ -1,33 +1,31 @@
-﻿using Microsoft.Maui.Controls;
-using Prism.Navigation;
+﻿using Prism.Navigation;
 
-namespace Prism.Ioc
+namespace Prism.Ioc;
+
+public static class NavigationRegistrationExtensions
 {
-    public static class NavigationRegistrationExtensions
+    public static IContainerRegistry RegisterForNavigation<TView>(this IContainerRegistry container, string name = null)
+        where TView : Page =>
+        container.RegisterForNavigation(typeof(TView), null, name);
+
+    public static IContainerRegistry RegisterForNavigation<TView, TViewModel>(this IContainerRegistry container, string name = null)
+        where TView : Page =>
+        container.RegisterForNavigation(typeof(TView), typeof(TViewModel), name);
+
+    public static IContainerRegistry RegisterForNavigation(this IContainerRegistry container, Type view, Type viewModel, string name = null)
     {
-        public static IContainerRegistry RegisterForNavigation<TView>(this IContainerRegistry container, string name = null)
-            where TView : Page =>
-            container.RegisterForNavigation(typeof(TView), null, name);
+        if (view is null)
+            throw new ArgumentNullException(nameof(view));
 
-        public static IContainerRegistry RegisterForNavigation<TView, TViewModel>(this IContainerRegistry container, string name = null)
-            where TView : Page =>
-            container.RegisterForNavigation(typeof(TView), typeof(TViewModel), name);
+        if (string.IsNullOrEmpty(name))
+            name = view.Name;
 
-        public static IContainerRegistry RegisterForNavigation(this IContainerRegistry container, Type view, Type viewModel, string name = null)
-        {
-            if (view is null)
-                throw new ArgumentNullException(nameof(view));
+        NavigationRegistry.Register(view, viewModel, name);
+        container.Register(view);
 
-            if (string.IsNullOrEmpty(name))
-                name = view.Name;
+        if (viewModel != null)
+            container.Register(viewModel);
 
-            NavigationRegistry.Register(view, viewModel, name);
-            container.Register(view);
-
-            if (viewModel != null)
-                container.Register(viewModel);
-
-            return container;
-        }
+        return container;
     }
 }

--- a/src/Prism.Maui/Modularity/IModuleCatalogExtensions.cs
+++ b/src/Prism.Maui/Modularity/IModuleCatalogExtensions.cs
@@ -1,95 +1,94 @@
-﻿namespace Prism.Modularity
+﻿namespace Prism.Modularity;
+
+/// <summary>
+/// <see cref="IModuleCatalog"/>  extensions.
+/// </summary>
+public static class IModuleCatalogExtensions
 {
     /// <summary>
-    /// <see cref="IModuleCatalog"/>  extensions.
+    /// Adds the module.
     /// </summary>
-    public static class IModuleCatalogExtensions
+    /// <returns>The module.</returns>
+    /// <param name="catalog">Catalog</param>
+    /// <param name="mode"><see cref="InitializationMode"/></param>
+    /// <typeparam name="T">The <see cref="IModule"/> type parameter.</typeparam>
+    public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, InitializationMode mode = InitializationMode.WhenAvailable)
+        where T : IModule =>
+        catalog.AddModule<T>(typeof(T).Name, mode);
+
+    /// <summary>
+    /// Adds the module.
+    /// </summary>
+    /// <returns>The module.</returns>
+    /// <param name="catalog">Catalog.</param>
+    /// <param name="name">Name.</param>
+    /// <typeparam name="T">The <see cref="IModule"/> type parameter.</typeparam>
+    public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name)
+        where T : IModule =>
+        catalog.AddModule<T>(name, InitializationMode.WhenAvailable);
+
+    /// <summary>
+    /// Adds the module.
+    /// </summary>
+    /// <returns>The module.</returns>
+    /// <param name="catalog">Catalog.</param>
+    /// <param name="name">Name.</param>
+    /// <param name="mode"><see cref="IModule"/>.</param>
+    /// <typeparam name="T">The <see cref="IModule"/> type parameter.</typeparam>
+    public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name, InitializationMode mode)
+        where T : IModule =>
+        catalog.AddModule(new ModuleInfo(typeof(T), name, mode));
+
+    /// <summary>
+    /// Adds the <see cref="IModule"/>
+    /// </summary>
+    /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
+    /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
+    /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
+    /// <returns>The <see cref="IModuleCatalog"/></returns>
+    public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, params string[] dependsOn)
+        where T : IModule => catalog.AddModule<T>(InitializationMode.WhenAvailable, dependsOn);
+
+    /// <summary>
+    /// Adds the <see cref="IModule"/>
+    /// </summary>
+    /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
+    /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
+    /// <param name="name">The name of the <see cref="IModule"/></param>
+    /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
+    /// <returns>The <see cref="IModuleCatalog"/></returns>
+    public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name, params string[] dependsOn)
+        where T : IModule =>
+        catalog.AddModule<T>(name, InitializationMode.WhenAvailable, dependsOn);
+
+    /// <summary>
+    /// Adds the <see cref="IModule"/>
+    /// </summary>
+    /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
+    /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
+    /// <param name="mode"></param>
+    /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
+    /// <returns>The <see cref="IModuleCatalog"/></returns>
+    public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, InitializationMode mode, params string[] dependsOn)
+        where T : IModule =>
+        catalog.AddModule<T>(typeof(T).Name, mode, dependsOn);
+
+    /// <summary>
+    /// Adds the <see cref="IModule"/>
+    /// </summary>
+    /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
+    /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
+    /// <param name="name">The name of the <see cref="IModule"/></param>
+    /// <param name="mode">The <see cref="InitializationMode"/></param>
+    /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
+    /// <returns>The <see cref="IModuleCatalog"/></returns>
+    public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name, InitializationMode mode, params string[] dependsOn)
+        where T : IModule
     {
-        /// <summary>
-        /// Adds the module.
-        /// </summary>
-        /// <returns>The module.</returns>
-        /// <param name="catalog">Catalog</param>
-        /// <param name="mode"><see cref="InitializationMode"/></param>
-        /// <typeparam name="T">The <see cref="IModule"/> type parameter.</typeparam>
-        public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, InitializationMode mode = InitializationMode.WhenAvailable)
-            where T : IModule =>
-            catalog.AddModule<T>(typeof(T).Name, mode);
-
-        /// <summary>
-        /// Adds the module.
-        /// </summary>
-        /// <returns>The module.</returns>
-        /// <param name="catalog">Catalog.</param>
-        /// <param name="name">Name.</param>
-        /// <typeparam name="T">The <see cref="IModule"/> type parameter.</typeparam>
-        public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name)
-            where T : IModule =>
-            catalog.AddModule<T>(name, InitializationMode.WhenAvailable);
-
-        /// <summary>
-        /// Adds the module.
-        /// </summary>
-        /// <returns>The module.</returns>
-        /// <param name="catalog">Catalog.</param>
-        /// <param name="name">Name.</param>
-        /// <param name="mode"><see cref="IModule"/>.</param>
-        /// <typeparam name="T">The <see cref="IModule"/> type parameter.</typeparam>
-        public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name, InitializationMode mode)
-            where T : IModule =>
-            catalog.AddModule(new ModuleInfo(typeof(T), name, mode));
-
-        /// <summary>
-        /// Adds the <see cref="IModule"/>
-        /// </summary>
-        /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
-        /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
-        /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
-        /// <returns>The <see cref="IModuleCatalog"/></returns>
-        public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, params string[] dependsOn)
-            where T : IModule => catalog.AddModule<T>(InitializationMode.WhenAvailable, dependsOn);
-
-        /// <summary>
-        /// Adds the <see cref="IModule"/>
-        /// </summary>
-        /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
-        /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
-        /// <param name="name">The name of the <see cref="IModule"/></param>
-        /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
-        /// <returns>The <see cref="IModuleCatalog"/></returns>
-        public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name, params string[] dependsOn)
-            where T : IModule =>
-            catalog.AddModule<T>(name, InitializationMode.WhenAvailable, dependsOn);
-
-        /// <summary>
-        /// Adds the <see cref="IModule"/>
-        /// </summary>
-        /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
-        /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
-        /// <param name="mode"></param>
-        /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
-        /// <returns>The <see cref="IModuleCatalog"/></returns>
-        public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, InitializationMode mode, params string[] dependsOn)
-            where T : IModule =>
-            catalog.AddModule<T>(typeof(T).Name, mode, dependsOn);
-
-        /// <summary>
-        /// Adds the <see cref="IModule"/>
-        /// </summary>
-        /// <typeparam name="T">Type of <see cref="IModule"/></typeparam>
-        /// <param name="catalog">The <see cref="IModuleCatalog"/> to add the <see cref="IModule"/> to.</param>
-        /// <param name="name">The name of the <see cref="IModule"/></param>
-        /// <param name="mode">The <see cref="InitializationMode"/></param>
-        /// <param name="dependsOn">The names of the <see cref="IModule"/>'s that should be loaded when this <see cref="IModule"/> is loaded.</param>
-        /// <returns>The <see cref="IModuleCatalog"/></returns>
-        public static IModuleCatalog AddModule<T>(this IModuleCatalog catalog, string name, InitializationMode mode, params string[] dependsOn)
-            where T : IModule
+        var moduleInfo = new ModuleInfo(name, typeof(T).AssemblyQualifiedName, dependsOn)
         {
-            var moduleInfo = new ModuleInfo(name, typeof(T).AssemblyQualifiedName, dependsOn)
-            {
-                InitializationMode = mode
-            };
-            return catalog.AddModule(moduleInfo);
-        }
+            InitializationMode = mode
+        };
+        return catalog.AddModule(moduleInfo);
     }
 }

--- a/src/Prism.Maui/Modularity/ModuleCatalog.cs
+++ b/src/Prism.Maui/Modularity/ModuleCatalog.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.Maui.Controls;
+﻿namespace Prism.Modularity;
 
-namespace Prism.Modularity
+[ContentProperty(nameof(Items))]
+public class ModuleCatalog : ModuleCatalogBase
 {
-    [ContentProperty(nameof(Items))]
-    public class ModuleCatalog : ModuleCatalogBase
-    {
 
-    }
 }

--- a/src/Prism.Maui/Modularity/ModuleInfo.cs
+++ b/src/Prism.Maui/Modularity/ModuleInfo.cs
@@ -1,159 +1,157 @@
 ﻿using System.Collections.ObjectModel;
 using System.Reflection;
-using Microsoft.Maui.Controls;
 using Prism.Properties;
 
-namespace Prism.Modularity
+namespace Prism.Modularity;
+
+[ContentProperty(nameof(DependsOn))]
+public partial class ModuleInfo : IModuleInfo
 {
-    [ContentProperty(nameof(DependsOn))]
-    public partial class ModuleInfo : IModuleInfo
+    /// <summary>
+    /// Initializes a new empty instance of <see cref="ModuleInfo"/>.
+    /// </summary>
+    public ModuleInfo()
     {
-        /// <summary>
-        /// Initializes a new empty instance of <see cref="ModuleInfo"/>.
-        /// </summary>
-        public ModuleInfo()
-        {
-        }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="ModuleInfo"/>.
-        /// </summary>
-        /// <param name="name">The module's name.</param>
-        /// <param name="type">The module <see cref="Type"/>'s AssemblyQualifiedName.</param>
-        /// <param name="dependsOn">The modules this instance depends on.</param>
-        /// <exception cref="ArgumentNullException">An <see cref="ArgumentNullException"/> is thrown if <paramref name="dependsOn"/> is <see langword="null"/>.</exception>
-        public ModuleInfo(string name, string type, params string[] dependsOn)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentNullException(nameof(name));
-            if (dependsOn == null)
-                throw new ArgumentNullException(nameof(dependsOn));
+    /// <summary>
+    /// Initializes a new instance of <see cref="ModuleInfo"/>.
+    /// </summary>
+    /// <param name="name">The module's name.</param>
+    /// <param name="type">The module <see cref="Type"/>'s AssemblyQualifiedName.</param>
+    /// <param name="dependsOn">The modules this instance depends on.</param>
+    /// <exception cref="ArgumentNullException">An <see cref="ArgumentNullException"/> is thrown if <paramref name="dependsOn"/> is <see langword="null"/>.</exception>
+    public ModuleInfo(string name, string type, params string[] dependsOn)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentNullException(nameof(name));
+        if (dependsOn == null)
+            throw new ArgumentNullException(nameof(dependsOn));
 
-            ModuleType = Type.GetType(type) ?? throw new ArgumentNullException(nameof(type));
-            ModuleName = name;
-            foreach (string dependency in dependsOn)
+        ModuleType = Type.GetType(type) ?? throw new ArgumentNullException(nameof(type));
+        ModuleName = name;
+        foreach (string dependency in dependsOn)
+        {
+            if (!DependsOn.Contains(dependency))
             {
+                DependsOn.Add(dependency);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ModuleInfo"/>.
+    /// </summary>
+    /// <param name="name">The module's name.</param>
+    /// <param name="type">The module's type.</param>
+    public ModuleInfo(string name, string type)
+        : this(name, type, Array.Empty<string>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ModuleInfo"/>.
+    /// </summary>
+    /// <param name="moduleType">The module's type.</param>
+    public ModuleInfo(Type moduleType)
+        : this(moduleType, moduleType.Name) { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ModuleInfo"/>.
+    /// </summary>
+    /// <param name="moduleType">The module's type.</param>
+    /// <param name="moduleName">The module's name.</param>
+    public ModuleInfo(Type moduleType, string moduleName)
+        : this(moduleType, moduleName, InitializationMode.WhenAvailable) { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ModuleInfo"/>.
+    /// </summary>
+    /// <param name="moduleType">The module's type.</param>
+    /// <param name="moduleName">The module's name.</param>
+    /// <param name="initializationMode">The module's <see cref="InitializationMode"/>.</param>
+    public ModuleInfo(Type moduleType, string moduleName, InitializationMode initializationMode)
+        : this(moduleName, moduleType.AssemblyQualifiedName)
+    {
+        InitializationMode = initializationMode;
+    }
+
+    private string _moduleName;
+    /// <summary>
+    /// Gets or sets the name of the module.
+    /// </summary>
+    /// <value>The name of the module.</value>
+    public string ModuleName
+    {
+        get => string.IsNullOrEmpty(_moduleName) ? ModuleType.Name : _moduleName;
+        set => _moduleName = value;
+    }
+
+    string IModuleInfo.ModuleType
+    {
+        get => ModuleType.AssemblyQualifiedName;
+        set => ModuleType = Type.GetType(value);
+    }
+
+    private Type _moduleType;
+    /// <summary>
+    /// Gets or sets the module <see cref="Type"/>'s AssemblyQualifiedName.
+    /// </summary>
+    /// <value>The type of the module.</value>
+    public Type ModuleType
+    {
+        get => _moduleType;
+        set
+        {
+            _moduleType = value;
+            ModuleName = value.Name;
+            foreach (var dependencyAttribute in value.GetCustomAttributes<ModuleDependencyAttribute>())
+            {
+                var dependency = dependencyAttribute.ModuleName;
                 if (!DependsOn.Contains(dependency))
                 {
                     DependsOn.Add(dependency);
                 }
             }
         }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="ModuleInfo"/>.
-        /// </summary>
-        /// <param name="name">The module's name.</param>
-        /// <param name="type">The module's type.</param>
-        public ModuleInfo(string name, string type)
-            : this(name, type, Array.Empty<string>())
-        {
-        }
+    private Collection<string> _dependsOn;
+    /// <summary>
+    /// Gets or sets the list of modules that this module depends upon.
+    /// </summary>
+    /// <value>The list of modules that this module depends upon.</value>
+    public Collection<string> DependsOn
+    {
+        get => _dependsOn ?? (_dependsOn = new Collection<string>());
+        set => _dependsOn = value;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="ModuleInfo"/>.
-        /// </summary>
-        /// <param name="moduleType">The module's type.</param>
-        public ModuleInfo(Type moduleType)
-            : this(moduleType, moduleType.Name) { }
+    /// <summary>
+    /// Specifies on which stage the Module will be initialized.
+    /// </summary>
+    public InitializationMode InitializationMode { get; set; }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="ModuleInfo"/>.
-        /// </summary>
-        /// <param name="moduleType">The module's type.</param>
-        /// <param name="moduleName">The module's name.</param>
-        public ModuleInfo(Type moduleType, string moduleName)
-            : this(moduleType, moduleName, InitializationMode.WhenAvailable) { }
+    /// <summary>
+    /// Reference to the location of the module assembly. Not Supported by Microsoft.Maui
+    /// </summary>
+    string IModuleInfo.Ref
+    {
+        get => throw new NotSupportedException(Resources.ModuleRefLocationNotSupported);
+        set { }
+    }
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="ModuleInfo"/>.
-        /// </summary>
-        /// <param name="moduleType">The module's type.</param>
-        /// <param name="moduleName">The module's name.</param>
-        /// <param name="initializationMode">The module's <see cref="InitializationMode"/>.</param>
-        public ModuleInfo(Type moduleType, string moduleName, InitializationMode initializationMode)
-            : this(moduleName, moduleType.AssemblyQualifiedName)
-        {
-            InitializationMode = initializationMode;
-        }
+    /// <summary>
+    /// Gets or sets the state of the <see cref="ModuleInfo"/> with regards to the module loading and initialization process.
+    /// </summary>
+    public ModuleState State { get; private set; }
 
-        private string _moduleName;
-        /// <summary>
-        /// Gets or sets the name of the module.
-        /// </summary>
-        /// <value>The name of the module.</value>
-        public string ModuleName
-        {
-            get => string.IsNullOrEmpty(_moduleName) ? ModuleType.Name : _moduleName;
-            set => _moduleName = value;
-        }
-
-        string IModuleInfo.ModuleType
-        {
-            get => ModuleType.AssemblyQualifiedName;
-            set => ModuleType = Type.GetType(value);
-        }
-
-        private Type _moduleType;
-        /// <summary>
-        /// Gets or sets the module <see cref="Type"/>'s AssemblyQualifiedName.
-        /// </summary>
-        /// <value>The type of the module.</value>
-        public Type ModuleType
-        {
-            get => _moduleType;
-            set
-            {
-                _moduleType = value;
-                ModuleName = value.Name;
-                foreach (var dependencyAttribute in value.GetCustomAttributes<ModuleDependencyAttribute>())
-                {
-                    var dependency = dependencyAttribute.ModuleName;
-                    if (!DependsOn.Contains(dependency))
-                    {
-                        DependsOn.Add(dependency);
-                    }
-                }
-            }
-        }
-
-        private Collection<string> _dependsOn;
-        /// <summary>
-        /// Gets or sets the list of modules that this module depends upon.
-        /// </summary>
-        /// <value>The list of modules that this module depends upon.</value>
-        public Collection<string> DependsOn
-        {
-            get => _dependsOn ?? (_dependsOn = new Collection<string>());
-            set => _dependsOn = value;
-        }
-
-        /// <summary>
-        /// Specifies on which stage the Module will be initialized.
-        /// </summary>
-        public InitializationMode InitializationMode { get; set; }
-
-        /// <summary>
-        /// Reference to the location of the module assembly. Not Supported by Microsoft.Maui
-        /// </summary>
-        string IModuleInfo.Ref
-        {
-            get => throw new NotSupportedException(Resources.ModuleRefLocationNotSupported);
-            set { }
-        }
-
-        /// <summary>
-        /// Gets or sets the state of the <see cref="ModuleInfo"/> with regards to the module loading and initialization process.
-        /// </summary>
-        public ModuleState State { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the state of the <see cref="ModuleInfo"/> with regards to the module loading and initialization process.
-        /// </summary>
-        ModuleState IModuleInfo.State
-        {
-            get => State;
-            set => State = value;
-        }
+    /// <summary>
+    /// Gets or sets the state of the <see cref="ModuleInfo"/> with regards to the module loading and initialization process.
+    /// </summary>
+    ModuleState IModuleInfo.State
+    {
+        get => State;
+        set => State = value;
     }
 }

--- a/src/Prism.Maui/Modularity/ModuleInitializer.cs
+++ b/src/Prism.Maui/Modularity/ModuleInitializer.cs
@@ -1,29 +1,28 @@
 ﻿using Prism.Ioc;
 
-namespace Prism.Modularity
+namespace Prism.Modularity;
+
+public class ModuleInitializer : IModuleInitializer
 {
-    public class ModuleInitializer : IModuleInitializer
+    readonly IContainerExtension _container;
+
+    public ModuleInitializer(IContainerExtension container)
     {
-        readonly IContainerExtension _container;
+        _container = container;
+    }
 
-        public ModuleInitializer(IContainerExtension container)
+    public void Initialize(IModuleInfo moduleInfo)
+    {
+        var module = CreateModule(Type.GetType(moduleInfo.ModuleType, true));
+        if (module != null)
         {
-            _container = container;
+            module.RegisterTypes(_container);
+            module.OnInitialized(_container);
         }
+    }
 
-        public void Initialize(IModuleInfo moduleInfo)
-        {
-            var module = CreateModule(Type.GetType(moduleInfo.ModuleType, true));
-            if (module != null)
-            {
-                module.RegisterTypes(_container);
-                module.OnInitialized(_container);
-            }
-        }
-
-        protected virtual IModule CreateModule(Type moduleType)
-        {
-            return (IModule)_container.Resolve(moduleType);
-        }
+    protected virtual IModule CreateModule(Type moduleType)
+    {
+        return (IModule)_container.Resolve(moduleType);
     }
 }

--- a/src/Prism.Maui/Modularity/ModuleManager.cs
+++ b/src/Prism.Maui/Modularity/ModuleManager.cs
@@ -1,126 +1,125 @@
 ﻿using System.Globalization;
 using Prism.Properties;
 
-namespace Prism.Modularity
+namespace Prism.Modularity;
+
+/// <summary>
+/// Component responsible for coordinating the modules' type loading and module initialization process. 
+/// </summary>
+public class ModuleManager : IModuleManager
 {
     /// <summary>
-    /// Component responsible for coordinating the modules' type loading and module initialization process. 
+    /// The module catalog.
     /// </summary>
-    public class ModuleManager : IModuleManager
+    protected IModuleCatalog ModuleCatalog { get; }
+
+    /// <summary>
+    /// Gets all the <see cref="IModuleInfo"/> classes that are in the <see cref="IModuleCatalog"/>.
+    /// </summary>
+    public IEnumerable<IModuleInfo> Modules => ModuleCatalog.Modules;
+
+    /// <summary>
+    /// Raised when a module is loaded or fails to load.
+    /// </summary>
+    public event EventHandler<LoadModuleCompletedEventArgs> LoadModuleCompleted;
+
+    /// <summary>
+    /// Not used by Prism.Maui
+    /// </summary>
+    public event EventHandler<ModuleDownloadProgressChangedEventArgs> ModuleDownloadProgressChanged
     {
-        /// <summary>
-        /// The module catalog.
-        /// </summary>
-        protected IModuleCatalog ModuleCatalog { get; }
+        add => throw new NotSupportedException();
+        remove => throw new NotSupportedException();
+    }
 
-        /// <summary>
-        /// Gets all the <see cref="IModuleInfo"/> classes that are in the <see cref="IModuleCatalog"/>.
-        /// </summary>
-        public IEnumerable<IModuleInfo> Modules => ModuleCatalog.Modules;
+    /// <summary>
+    /// The module initializer.
+    /// </summary>
+    protected IModuleInitializer ModuleInitializer { get; }
 
-        /// <summary>
-        /// Raised when a module is loaded or fails to load.
-        /// </summary>
-        public event EventHandler<LoadModuleCompletedEventArgs> LoadModuleCompleted;
+    /// <summary>
+    /// Initializes an instance of the <see cref="ModuleManager"/> class.
+    /// </summary>
+    /// <param name="moduleInitializer">Service used for initialization of modules.</param>
+    /// <param name="moduleCatalog">Catalog that enumerates the modules to be loaded and initialized.</param>
+    public ModuleManager(IModuleInitializer moduleInitializer, IModuleCatalog moduleCatalog)
+    {
+        ModuleInitializer = moduleInitializer ?? throw new ArgumentNullException(nameof(moduleInitializer));
+        ModuleCatalog = moduleCatalog ?? throw new ArgumentNullException(nameof(moduleCatalog));
+    }
 
-        /// <summary>
-        /// Not used by Prism.Maui
-        /// </summary>
-        public event EventHandler<ModuleDownloadProgressChangedEventArgs> ModuleDownloadProgressChanged
+    /// <summary>
+    /// Initializes the modules marked as <see cref="InitializationMode.WhenAvailable"/> in the <see cref="ModuleCatalog"/>.
+    /// </summary>
+    public void Run()
+    {
+        LoadModulesWhenAvailable();
+    }
+
+    /// <summary>
+    /// Loads and initializes the module in the <see cref="IModuleCatalog"/> with the name <paramref name="moduleName"/>.
+    /// </summary>
+    /// <param name="moduleName">Name of the module requested for initialization.</param>
+    public void LoadModule(string moduleName)
+    {
+        var modules = ModuleCatalog.Modules.Where(m => m.ModuleName == moduleName);
+        if (modules == null || modules.Count() == 0)
         {
-            add => throw new NotSupportedException();
-            remove => throw new NotSupportedException();
+            throw new ModuleNotFoundException(moduleName, string.Format(CultureInfo.CurrentCulture, Resources.ModuleNotFound, moduleName));
+        }
+        else if (modules.Count() > 1)
+        {
+            throw new DuplicateModuleException(moduleName, string.Format(CultureInfo.CurrentCulture, Resources.DuplicatedModuleInCatalog, moduleName));
         }
 
-        /// <summary>
-        /// The module initializer.
-        /// </summary>
-        protected IModuleInitializer ModuleInitializer { get; }
+        var modulesToLoad = ModuleCatalog.CompleteListWithDependencies(modules);
 
-        /// <summary>
-        /// Initializes an instance of the <see cref="ModuleManager"/> class.
-        /// </summary>
-        /// <param name="moduleInitializer">Service used for initialization of modules.</param>
-        /// <param name="moduleCatalog">Catalog that enumerates the modules to be loaded and initialized.</param>
-        public ModuleManager(IModuleInitializer moduleInitializer, IModuleCatalog moduleCatalog)
-        {
-            ModuleInitializer = moduleInitializer ?? throw new ArgumentNullException(nameof(moduleInitializer));
-            ModuleCatalog = moduleCatalog ?? throw new ArgumentNullException(nameof(moduleCatalog));
-        }
+        LoadModules(modulesToLoad);
+    }
 
-        /// <summary>
-        /// Initializes the modules marked as <see cref="InitializationMode.WhenAvailable"/> in the <see cref="ModuleCatalog"/>.
-        /// </summary>
-        public void Run()
-        {
-            LoadModulesWhenAvailable();
-        }
+    /// <summary>
+    /// Loads the <see cref="IModule"/>'s with <see cref="InitializationMode.WhenAvailable"/>
+    /// </summary>
+    protected void LoadModulesWhenAvailable()
+    {
+        var whenAvailableModules = ModuleCatalog.Modules.Where(m => m.InitializationMode == InitializationMode.WhenAvailable && m.State == ModuleState.NotStarted);
+        if (whenAvailableModules != null)
+            LoadModules(whenAvailableModules);
+    }
 
-        /// <summary>
-        /// Loads and initializes the module in the <see cref="IModuleCatalog"/> with the name <paramref name="moduleName"/>.
-        /// </summary>
-        /// <param name="moduleName">Name of the module requested for initialization.</param>
-        public void LoadModule(string moduleName)
+    /// <summary>
+    /// Loads the specified modules.
+    /// </summary>
+    /// <param name="moduleInfos"><see cref="IModuleInfo"/>.</param>
+    protected virtual void LoadModules(IEnumerable<IModuleInfo> moduleInfos)
+    {
+        foreach (var moduleInfo in moduleInfos)
         {
-            var modules = ModuleCatalog.Modules.Where(m => m.ModuleName == moduleName);
-            if (modules == null || modules.Count() == 0)
+            if (moduleInfo.State == ModuleState.NotStarted)
             {
-                throw new ModuleNotFoundException(moduleName, string.Format(CultureInfo.CurrentCulture, Resources.ModuleNotFound, moduleName));
-            }
-            else if (modules.Count() > 1)
-            {
-                throw new DuplicateModuleException(moduleName, string.Format(CultureInfo.CurrentCulture, Resources.DuplicatedModuleInCatalog, moduleName));
-            }
-
-            var modulesToLoad = ModuleCatalog.CompleteListWithDependencies(modules);
-
-            LoadModules(modulesToLoad);
-        }
-
-        /// <summary>
-        /// Loads the <see cref="IModule"/>'s with <see cref="InitializationMode.WhenAvailable"/>
-        /// </summary>
-        protected void LoadModulesWhenAvailable()
-        {
-            var whenAvailableModules = ModuleCatalog.Modules.Where(m => m.InitializationMode == InitializationMode.WhenAvailable && m.State == ModuleState.NotStarted);
-            if (whenAvailableModules != null)
-                LoadModules(whenAvailableModules);
-        }
-
-        /// <summary>
-        /// Loads the specified modules.
-        /// </summary>
-        /// <param name="moduleInfos"><see cref="IModuleInfo"/>.</param>
-        protected virtual void LoadModules(IEnumerable<IModuleInfo> moduleInfos)
-        {
-            foreach (var moduleInfo in moduleInfos)
-            {
-                if (moduleInfo.State == ModuleState.NotStarted)
+                try
                 {
-                    try
-                    {
-                        moduleInfo.State = ModuleState.Initializing;
-                        ModuleInitializer.Initialize(moduleInfo);
-                        moduleInfo.State = ModuleState.Initialized;
-                        RaiseLoadModuleCompleted(moduleInfo);
-                    }
-                    catch (Exception ex)
-                    {
-                        RaiseLoadModuleCompleted(moduleInfo, ex);
-                    }
-
+                    moduleInfo.State = ModuleState.Initializing;
+                    ModuleInitializer.Initialize(moduleInfo);
+                    moduleInfo.State = ModuleState.Initialized;
+                    RaiseLoadModuleCompleted(moduleInfo);
                 }
+                catch (Exception ex)
+                {
+                    RaiseLoadModuleCompleted(moduleInfo, ex);
+                }
+
             }
         }
+    }
 
-        /// <summary>
-        /// Raises the <see cref="LoadModuleCompleted"/> event.
-        /// </summary>
-        /// <param name="moduleInfo">The <see cref="IModuleInfo"/> that was just loaded.</param>
-        /// <param name="ex">An <see cref="Exception"/> if any that was thrown during the loading of the <see cref="IModule"/></param>
-        protected void RaiseLoadModuleCompleted(IModuleInfo moduleInfo, Exception ex = null)
-        {
-            LoadModuleCompleted?.Invoke(this, new LoadModuleCompletedEventArgs(moduleInfo, ex));
-        }
+    /// <summary>
+    /// Raises the <see cref="LoadModuleCompleted"/> event.
+    /// </summary>
+    /// <param name="moduleInfo">The <see cref="IModuleInfo"/> that was just loaded.</param>
+    /// <param name="ex">An <see cref="Exception"/> if any that was thrown during the loading of the <see cref="IModule"/></param>
+    protected void RaiseLoadModuleCompleted(IModuleInfo moduleInfo, Exception ex = null)
+    {
+        LoadModuleCompleted?.Invoke(this, new LoadModuleCompletedEventArgs(moduleInfo, ex));
     }
 }

--- a/src/Prism.Maui/Navigation/Builder/CreateTabBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/CreateTabBuilder.cs
@@ -1,0 +1,29 @@
+﻿using System.Web;
+
+namespace Prism.Navigation.Builder;
+
+internal class CreateTabBuilder : ICreateTabBuilder, IUriSegment
+{
+    private List<IUriSegment> _segments { get; }
+
+    public CreateTabBuilder()
+    {
+        _segments = new List<IUriSegment>();
+    }
+
+    public string Segment => BuildSegment();
+
+    public ICreateTabBuilder AddNavigationSegment(string segmentName, Action<ISegmentBuilder> configureSegment)
+    {
+        var builder = new SegmentBuilder(segmentName);
+        configureSegment?.Invoke(builder);
+        _segments.Add(builder);
+        return this;
+    }
+
+    private string BuildSegment()
+    {
+        var uri = string.Join("/", _segments.Select(x => x.Segment));
+        return HttpUtility.UrlEncode(uri);
+    }
+}

--- a/src/Prism.Maui/Navigation/Builder/IConfigurableSegmentName.cs
+++ b/src/Prism.Maui/Navigation/Builder/IConfigurableSegmentName.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Navigation.Builder;
+
+internal interface IConfigurableSegmentName
+{
+    string SegmentName { get; }
+}

--- a/src/Prism.Maui/Navigation/Builder/ICreateTabBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/ICreateTabBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Navigation.Builder;
+
+public interface ICreateTabBuilder
+{
+    ICreateTabBuilder AddNavigationSegment(string segmentName, Action<ISegmentBuilder> configureSegment);
+}

--- a/src/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace Prism.Navigation.Builder;
+
+public interface INavigationBuilder
+{
+    INavigationBuilder AddNavigationSegment(string segmentName, Action<ISegmentBuilder> configureSegment);
+    INavigationBuilder AddTabbedSegment(Action<ITabbedSegmentBuilder> configuration);
+    INavigationBuilder WithParameters(INavigationParameters parameters);
+    INavigationBuilder AddParameter(string key, object value);
+
+    INavigationBuilder UseAbsoluteNavigation(bool absolute);
+    INavigationBuilder UseRelativeNavigation();
+
+    Task<INavigationResult> NavigateAsync();
+    Task NavigateAsync(Action<Exception> onError);
+    Task NavigateAsync(Action onSuccess, Action<Exception> onError);
+}

--- a/src/Prism.Maui/Navigation/Builder/ISegmentBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/ISegmentBuilder.cs
@@ -1,0 +1,10 @@
+﻿namespace Prism.Navigation.Builder;
+
+public interface ISegmentBuilder
+{
+    string SegmentName { get; }
+
+    ISegmentBuilder AddSegmentParameter(string key, object value);
+
+    ISegmentBuilder UseModalNavigation(bool useModalNavigation);
+}

--- a/src/Prism.Maui/Navigation/Builder/ITabbedNavigationBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/ITabbedNavigationBuilder.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+
+namespace Prism.Navigation.Builder;
+
+public interface ITabbedNavigationBuilder : INavigationBuilder
+{
+    ITabbedNavigationBuilder CreateTab(string segmentNameOrUri);
+    ITabbedNavigationBuilder CreateTab<TViewModel>()
+        where TViewModel : class, INotifyPropertyChanged;
+    ITabbedNavigationBuilder SelectTab(string segmentNameOrUri);
+    ITabbedNavigationBuilder SelectTab<TViewModel>()
+        where TViewModel : class, INotifyPropertyChanged;
+}

--- a/src/Prism.Maui/Navigation/Builder/ITabbedSegmentBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/ITabbedSegmentBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace Prism.Navigation.Builder;
+
+public interface ITabbedSegmentBuilder
+{
+    ITabbedSegmentBuilder CreateTab(Action<ICreateTabBuilder> configureSegment);
+
+    ITabbedSegmentBuilder SelectedTab(string segmentName);
+
+    ITabbedSegmentBuilder AddSegmentParameter(string key, object value);
+
+    ITabbedSegmentBuilder UseModalNavigation(bool useModalNavigation);
+}

--- a/src/Prism.Maui/Navigation/Builder/IUriSegment.cs
+++ b/src/Prism.Maui/Navigation/Builder/IUriSegment.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Navigation.Builder;
+
+internal interface IUriSegment
+{
+    string Segment { get; }
+}

--- a/src/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
@@ -1,0 +1,86 @@
+﻿namespace Prism.Navigation.Builder;
+
+internal class NavigationBuilder : INavigationBuilder
+{
+    internal static readonly Uri RootUri = new Uri("app://prismapp.maui", UriKind.Absolute);
+
+    private INavigationService _navigationService { get; }
+    private INavigationParameters _navigationParameters { get; }
+    private bool _absoluteNavigation;
+    private List<IUriSegment> _uriSegments { get; }
+
+    public NavigationBuilder(INavigationService navigationService)
+    {
+        _navigationService = navigationService;
+        _navigationParameters = new NavigationParameters();
+        _uriSegments = new List<IUriSegment>();
+    }
+
+    public INavigationBuilder AddNavigationSegment(string segmentName, Action<ISegmentBuilder> configureSegment)
+    {
+        var builder = new SegmentBuilder(segmentName);
+        configureSegment?.Invoke(builder);
+        _uriSegments.Add(builder);
+        return this;
+    }
+
+    public INavigationBuilder AddTabbedSegment(Action<ITabbedSegmentBuilder> configureSegment)
+    {
+        var builder = new TabbedSegmentBuilder();
+        configureSegment?.Invoke(builder);
+        _uriSegments.Add(builder);
+        return this;
+    }
+
+    public INavigationBuilder AddParameter(string key, object value)
+    {
+        _navigationParameters.Add(key, value);
+        return this;
+    }
+
+    public Task<INavigationResult> NavigateAsync()
+    {
+        return _navigationService.NavigateAsync(BuildUri(), _navigationParameters);
+    }
+
+    public Task NavigateAsync(Action<Exception> onError)
+    {
+        return NavigateAsync(() => { }, onError);
+    }
+
+    public async Task NavigateAsync(Action onSuccess, Action<Exception> onError)
+    {
+        var result = await NavigateAsync();
+        if (result.Exception != null)
+            onError?.Invoke(result.Exception);
+        else if (result.Success)
+            onSuccess?.Invoke();
+    }
+
+    public INavigationBuilder UseAbsoluteNavigation(bool absolute)
+    {
+        _absoluteNavigation = absolute;
+        return this;
+    }
+
+    public INavigationBuilder UseRelativeNavigation()
+    {
+        _absoluteNavigation = false;
+        return this;
+    }
+
+    public INavigationBuilder WithParameters(INavigationParameters parameters)
+    {
+        foreach ((var key, var value) in parameters)
+            _navigationParameters.Add(key, value);
+
+        return this;
+    }
+
+    internal Uri BuildUri()
+    {
+        var uri = string.Join("/", _uriSegments.Select(x => x.Segment));
+
+        return _absoluteNavigation ? new Uri(RootUri, uri) : new Uri(uri, UriKind.Relative);
+    }
+}

--- a/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
+++ b/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
@@ -27,6 +27,14 @@ public static class NavigationBuilderExtensions
                 o.UseModalNavigation(useModalNavigation.Value);
         });
 
+    public static ICreateTabBuilder AddNavigationSegment<TViewModel>(this ICreateTabBuilder builder)
+        where TViewModel : class, INotifyPropertyChanged =>
+        builder.AddNavigationSegment<TViewModel>(b => { });
+
+    public static ICreateTabBuilder AddNavigationSegment<TViewModel>(this ICreateTabBuilder builder, Action<ISegmentBuilder> configureSegment)
+        where TViewModel : class, INotifyPropertyChanged =>
+        builder.AddNavigationSegment(GetNavigationKey<TViewModel>(), configureSegment);
+
     public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder)
         where TViewModel : class, INotifyPropertyChanged =>
         builder.AddNavigationSegment<TViewModel>(b => { });
@@ -44,6 +52,19 @@ public static class NavigationBuilderExtensions
         builder.AddNavigationPage(b => { });
 
     public static INavigationBuilder AddNavigationPage(this INavigationBuilder builder, Action<ISegmentBuilder> configureSegment)
+    {
+        var registrationInfo = NavigationRegistry.Registrations
+            .FirstOrDefault(x => x.View.IsAssignableTo(typeof(NavigationPage)));
+        if (registrationInfo is null)
+            throw new NavigationException(NavigationException.NoPageIsRegistered, nameof(NavigationPage));
+
+        return builder.AddNavigationSegment(registrationInfo.Name, configureSegment);
+    }
+
+    public static ICreateTabBuilder AddNavigationPage(this ICreateTabBuilder builder) =>
+        builder.AddNavigationPage(b => { });
+
+    public static ICreateTabBuilder AddNavigationPage(this ICreateTabBuilder builder, Action<ISegmentBuilder> configureSegment)
     {
         var registrationInfo = NavigationRegistry.Registrations
             .FirstOrDefault(x => x.View.IsAssignableTo(typeof(NavigationPage)));

--- a/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
+++ b/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
@@ -1,0 +1,122 @@
+﻿using System.ComponentModel;
+using Prism.Navigation.Builder;
+
+namespace Prism.Navigation;
+
+public static class NavigationBuilderExtensions
+{
+    public static INavigationBuilder CreateBuilder(this INavigationService navigationService) =>
+           new NavigationBuilder(navigationService);
+
+    internal static string GetNavigationKey<TViewModel>()
+    {
+        var vmType = typeof(TViewModel);
+        if (vmType.IsAssignableFrom(typeof(VisualElement)))
+            throw new NavigationException(NavigationException.MvvmPatternBreak, typeof(TViewModel).Name);
+
+        return NavigationRegistry.GetViewModelNavigationKey(vmType);
+    }
+
+    public static INavigationBuilder UseAbsoluteNavigation(this INavigationBuilder builder) =>
+        builder.UseAbsoluteNavigation(true);
+
+    public static INavigationBuilder AddNavigationSegment(this INavigationBuilder builder, string segmentName, bool? useModalNavigation = null) =>
+        builder.AddNavigationSegment(segmentName, o =>
+        {
+            if (useModalNavigation.HasValue)
+                o.UseModalNavigation(useModalNavigation.Value);
+        });
+
+    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder)
+        where TViewModel : class, INotifyPropertyChanged =>
+        builder.AddNavigationSegment<TViewModel>(b => { });
+
+    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder, Action<ISegmentBuilder> configureSegment)
+        where TViewModel : class, INotifyPropertyChanged =>
+        builder.AddNavigationSegment(GetNavigationKey<TViewModel>(), configureSegment);
+
+    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder, bool useModalNavigation)
+        where TViewModel : class, INotifyPropertyChanged =>
+        builder.AddNavigationSegment<TViewModel>(b => b.UseModalNavigation(useModalNavigation));
+
+    // Will check for the Navigation key of a registered NavigationPage
+    public static INavigationBuilder AddNavigationPage(this INavigationBuilder builder) =>
+        builder.AddNavigationPage(b => { });
+
+    public static INavigationBuilder AddNavigationPage(this INavigationBuilder builder, Action<ISegmentBuilder> configureSegment)
+    {
+        var registrationInfo = NavigationRegistry.Registrations
+            .FirstOrDefault(x => x.View.IsAssignableTo(typeof(NavigationPage)));
+        if (registrationInfo is null)
+            throw new NavigationException(NavigationException.NoPageIsRegistered, nameof(NavigationPage));
+
+        return builder.AddNavigationSegment(registrationInfo.Name, configureSegment);
+    }
+
+    public static INavigationBuilder AddNavigationPage(this INavigationBuilder builder, bool useModalNavigation) =>
+        builder.AddNavigationPage(o => o.UseModalNavigation(useModalNavigation));
+
+    //public static INavigationBuilder AddNavigationSegment(this INavigationBuilder builder, string segmentName, params string[] createTabs)
+    //{
+    //    return builder;
+    //}
+
+    //public static INavigationBuilder AddNavigationSegment(this INavigationBuilder builder, string segmentName, bool useModalNavigation, params string[] createTabs)
+    //{
+    //    return builder;
+    //}
+
+    //public static INavigationBuilder AddNavigationSegment(this INavigationBuilder builder, string segmentName, string selectTab, bool? useModalNavigation, params string[] createTabs)
+    //{
+    //    return builder;
+    //}
+
+    public static async void Navigate(this INavigationBuilder builder)
+    {
+        await builder.NavigateAsync();
+    }
+
+    public static async void Navigate(this INavigationBuilder builder, Action<Exception> onError)
+    {
+        await builder.NavigateAsync(onError);
+    }
+
+    public static async void Navigate(this INavigationBuilder builder, Action onSuccess)
+    {
+        await builder.NavigateAsync(onSuccess, _ => { });
+    }
+
+    public static async void Navigate(this INavigationBuilder builder, Action onSuccess, Action<Exception> onError)
+    {
+        await builder.NavigateAsync(onSuccess, onError);
+    }
+
+    public static ISegmentBuilder UseModalNavigation(this ISegmentBuilder builder) =>
+        builder.UseModalNavigation(true);
+
+    public static ICreateTabBuilder AddNavigationSegment(this ICreateTabBuilder builder, string segmentNameOrUri) =>
+            builder.AddNavigationSegment(segmentNameOrUri, null);
+
+    public static ITabbedSegmentBuilder CreateTab(this ITabbedSegmentBuilder builder, string segmentName, Action<ISegmentBuilder> configureSegment) =>
+        builder.CreateTab(o => o.AddNavigationSegment(segmentName, configureSegment));
+
+    public static ITabbedSegmentBuilder CreateTab(this ITabbedSegmentBuilder builder, string segmentNameOrUri) =>
+        builder.CreateTab(o => o.AddNavigationSegment(segmentNameOrUri));
+
+    public static ITabbedSegmentBuilder CreateTab<TViewModel>(this ITabbedSegmentBuilder builder)
+        where TViewModel : class, INotifyPropertyChanged
+    {
+        var navigationKey = GetNavigationKey<TViewModel>();
+        return builder.CreateTab(navigationKey);
+    }
+
+    public static ITabbedSegmentBuilder SelectTab<TViewModel>(this ITabbedSegmentBuilder builder)
+        where TViewModel : class, INotifyPropertyChanged
+    {
+        var navigationKey = GetNavigationKey<TViewModel>();
+        return builder.SelectedTab(navigationKey);
+    }
+
+    public static ITabbedNavigationBuilder SelectTab(this ITabbedNavigationBuilder builder, params string[] navigationSegments) =>
+        builder.SelectTab(string.Join("|", navigationSegments));
+}

--- a/src/Prism.Maui/Navigation/Builder/SegmentBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/SegmentBuilder.cs
@@ -1,0 +1,35 @@
+﻿namespace Prism.Navigation.Builder;
+
+internal class SegmentBuilder : ISegmentBuilder, IConfigurableSegmentName, IUriSegment
+{
+    private INavigationParameters _parameters { get; }
+
+    public SegmentBuilder(string segmentName)
+    {
+        _parameters = new NavigationParameters();
+        SegmentName = segmentName;
+    }
+
+    public string SegmentName { get; set; }
+
+    public string Segment => BuildSegment();
+
+    public ISegmentBuilder AddSegmentParameter(string key, object value)
+    {
+        _parameters.Add(key, value);
+        return this;
+    }
+
+    public ISegmentBuilder UseModalNavigation(bool useModalNavigation)
+    {
+        return AddSegmentParameter(KnownNavigationParameters.UseModalNavigation, useModalNavigation);
+    }
+
+    private string BuildSegment()
+    {
+        if (!_parameters.Any())
+            return SegmentName;
+
+        return SegmentName + _parameters.ToString();
+    }
+}

--- a/src/Prism.Maui/Navigation/Builder/TabbedSegmentBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/TabbedSegmentBuilder.cs
@@ -1,0 +1,58 @@
+﻿namespace Prism.Navigation.Builder;
+
+internal class TabbedSegmentBuilder : ITabbedSegmentBuilder, IConfigurableSegmentName, IUriSegment
+{
+    private INavigationParameters _parameters { get; }
+
+    public TabbedSegmentBuilder()
+    {
+        _parameters = new NavigationParameters();
+
+        var registrationInfo = NavigationRegistry.Registrations
+            .FirstOrDefault(x => x.View.IsAssignableFrom(typeof(TabbedPage)));
+        if (registrationInfo is null)
+            throw new NavigationException(NavigationException.NoPageIsRegistered);
+
+        SegmentName = registrationInfo.Name;
+    }
+
+    public string SegmentName { get; set; }
+
+    public string Segment => BuildSegment();
+
+    public ITabbedSegmentBuilder AddSegmentParameter(string key, object value)
+    {
+        _parameters.Add(key, value);
+        return this;
+    }
+
+    public ITabbedSegmentBuilder UseModalNavigation(bool useModalNavigation)
+    {
+        return AddSegmentParameter(KnownNavigationParameters.UseModalNavigation, useModalNavigation);
+    }
+
+    public ITabbedSegmentBuilder CreateTab(Action<ICreateTabBuilder> configureSegment)
+    {
+        if (configureSegment is null)
+        {
+            throw new ArgumentNullException(nameof(configureSegment));
+        }
+
+        var builder = new CreateTabBuilder();
+        configureSegment(builder);
+        return AddSegmentParameter(KnownNavigationParameters.CreateTab, builder.Segment);
+    }
+
+    public ITabbedSegmentBuilder SelectedTab(string segmentName)
+    {
+        return AddSegmentParameter(KnownNavigationParameters.SelectedTab, segmentName);
+    }
+
+    private string BuildSegment()
+    {
+        if (!_parameters.Any())
+            return SegmentName;
+
+        return SegmentName + _parameters.ToString();
+    }
+}

--- a/src/Prism.Maui/Navigation/IConfirmNavigation.cs
+++ b/src/Prism.Maui/Navigation/IConfirmNavigation.cs
@@ -1,15 +1,14 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// Provides a way for ViewModels involved in navigation to determine if a navigation request should continue.
+/// </summary>
+public interface IConfirmNavigation
 {
     /// <summary>
-    /// Provides a way for ViewModels involved in navigation to determine if a navigation request should continue.
+    /// Determines whether this instance accepts being navigated away from.
     /// </summary>
-    public interface IConfirmNavigation
-    {
-        /// <summary>
-        /// Determines whether this instance accepts being navigated away from.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters.</param>
-        /// <returns><c>True</c> if navigation can continue, <c>False</c> if navigation is not allowed to continue</returns>
-        bool CanNavigate(INavigationParameters parameters);
-    }
+    /// <param name="parameters">The navigation parameters.</param>
+    /// <returns><c>True</c> if navigation can continue, <c>False</c> if navigation is not allowed to continue</returns>
+    bool CanNavigate(INavigationParameters parameters);
 }

--- a/src/Prism.Maui/Navigation/IConfirmNavigationAsync.cs
+++ b/src/Prism.Maui/Navigation/IConfirmNavigationAsync.cs
@@ -1,15 +1,14 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// Provides a way for ViewModels involved in navigation to asynchronously determine if a navigation request should continue.
+/// </summary>
+public interface IConfirmNavigationAsync
 {
     /// <summary>
-    /// Provides a way for ViewModels involved in navigation to asynchronously determine if a navigation request should continue.
+    /// Determines whether this instance accepts being navigated away from.
     /// </summary>
-    public interface IConfirmNavigationAsync
-    {
-        /// <summary>
-        /// Determines whether this instance accepts being navigated away from.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters.</param>
-        /// <returns><c>True</c> if navigation can continue, <c>False</c> if navigation is not allowed to continue</returns>
-        Task<bool> CanNavigateAsync(INavigationParameters parameters);
-    }
+    /// <param name="parameters">The navigation parameters.</param>
+    /// <returns><c>True</c> if navigation can continue, <c>False</c> if navigation is not allowed to continue</returns>
+    Task<bool> CanNavigateAsync(INavigationParameters parameters);
 }

--- a/src/Prism.Maui/Navigation/IFlyoutPageOptions.cs
+++ b/src/Prism.Maui/Navigation/IFlyoutPageOptions.cs
@@ -1,13 +1,12 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// Provides a way for the <see cref="INavigationService" /> to know whether the Flyout should be presented after navigation.
+/// </summary>
+public interface IFlyoutPageOptions
 {
     /// <summary>
-    /// Provides a way for the <see cref="INavigationService" /> to know whether the Flyout should be presented after navigation.
+    /// The INavigationService uses the result of this property to determine if the FlyoutPage.Flyout should be presented after navigation.
     /// </summary>
-    public interface IFlyoutPageOptions
-    {
-        /// <summary>
-        /// The INavigationService uses the result of this property to determine if the FlyoutPage.Flyout should be presented after navigation.
-        /// </summary>
-        bool IsPresentedAfterNavigation { get; }
-    }
+    bool IsPresentedAfterNavigation { get; }
 }

--- a/src/Prism.Maui/Navigation/IInitialize.cs
+++ b/src/Prism.Maui/Navigation/IInitialize.cs
@@ -1,7 +1,6 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+public interface IInitialize
 {
-    public interface IInitialize
-    {
-        void Initialize(INavigationParameters parameters);
-    }
+    void Initialize(INavigationParameters parameters);
 }

--- a/src/Prism.Maui/Navigation/IInitializeAsync.cs
+++ b/src/Prism.Maui/Navigation/IInitializeAsync.cs
@@ -1,7 +1,6 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+public interface IInitializeAsync
 {
-    public interface IInitializeAsync
-    {
-        Task InitializeAsync(INavigationParameters parameters);
-    }
+    Task InitializeAsync(INavigationParameters parameters);
 }

--- a/src/Prism.Maui/Navigation/INavigatedAware.cs
+++ b/src/Prism.Maui/Navigation/INavigatedAware.cs
@@ -1,20 +1,19 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// Provides a way for ViewModels involved in navigation to be notified of navigation activities after the target Page has been added to the navigation stack.
+/// </summary>
+public interface INavigatedAware
 {
     /// <summary>
-    /// Provides a way for ViewModels involved in navigation to be notified of navigation activities after the target Page has been added to the navigation stack.
+    /// Called when the implementer has been navigated away from.
     /// </summary>
-    public interface INavigatedAware
-    {
-        /// <summary>
-        /// Called when the implementer has been navigated away from.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters.</param>
-        void OnNavigatedFrom(INavigationParameters parameters);
+    /// <param name="parameters">The navigation parameters.</param>
+    void OnNavigatedFrom(INavigationParameters parameters);
 
-        /// <summary>
-        /// Called when the implementer has been navigated to.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters.</param>
-        void OnNavigatedTo(INavigationParameters parameters);
-    }
+    /// <summary>
+    /// Called when the implementer has been navigated to.
+    /// </summary>
+    /// <param name="parameters">The navigation parameters.</param>
+    void OnNavigatedTo(INavigationParameters parameters);
 }

--- a/src/Prism.Maui/Navigation/INavigationAware.cs
+++ b/src/Prism.Maui/Navigation/INavigationAware.cs
@@ -1,10 +1,9 @@
-﻿namespace Prism.Navigation
-{
-    /// <summary>
-    /// Provides a way for ViewModels involved in navigation to be notified of navigation activities.
-    /// </summary>
-    public interface INavigationAware : INavigatedAware
-    {
+﻿namespace Prism.Navigation;
 
-    }
+/// <summary>
+/// Provides a way for ViewModels involved in navigation to be notified of navigation activities.
+/// </summary>
+public interface INavigationAware : INavigatedAware
+{
+
 }

--- a/src/Prism.Maui/Navigation/INavigationPageOptions.cs
+++ b/src/Prism.Maui/Navigation/INavigationPageOptions.cs
@@ -1,14 +1,13 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// Provides a way for the INavigationService to make decisions regarding a NavigationPage during navigation.
+/// </summary>
+public interface INavigationPageOptions
 {
     /// <summary>
-    /// Provides a way for the INavigationService to make decisions regarding a NavigationPage during navigation.
+    /// The INavigationService uses the result of this property to determine if the NavigationPage should clear the NavigationStack when navigating to a new Page.
     /// </summary>
-    public interface INavigationPageOptions
-    {
-        /// <summary>
-        /// The INavigationService uses the result of this property to determine if the NavigationPage should clear the NavigationStack when navigating to a new Page.
-        /// </summary>
-        /// <remarks>This is equivalent to calling PopToRoot, and then replacing the current Page with the target Page being navigated to.</remarks>
-        bool ClearNavigationStackOnNavigation { get; }
-    }
+    /// <remarks>This is equivalent to calling PopToRoot, and then replacing the current Page with the target Page being navigated to.</remarks>
+    bool ClearNavigationStackOnNavigation { get; }
 }

--- a/src/Prism.Maui/Navigation/INavigationParameters.cs
+++ b/src/Prism.Maui/Navigation/INavigationParameters.cs
@@ -1,11 +1,10 @@
 ﻿using Prism.Common;
 
-namespace Prism.Navigation
+namespace Prism.Navigation;
+
+/// <summary>
+/// Provides a way for the <see cref="INavigationService"/> to pass parameters during navigation.
+/// </summary>
+public interface INavigationParameters : IParameters
 {
-    /// <summary>
-    /// Provides a way for the <see cref="INavigationService"/> to pass parameters during navigation.
-    /// </summary>
-    public interface INavigationParameters : IParameters
-    {
-    }
 }

--- a/src/Prism.Maui/Navigation/INavigationParametersInternal.cs
+++ b/src/Prism.Maui/Navigation/INavigationParametersInternal.cs
@@ -1,30 +1,29 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// Used to set internal parameters used by Prism's <see cref="INavigationService"/>
+/// </summary>
+public interface INavigationParametersInternal
 {
     /// <summary>
-    /// Used to set internal parameters used by Prism's <see cref="INavigationService"/>
+    /// Adds the key and value to the parameters Collection
     /// </summary>
-    public interface INavigationParametersInternal
-    {
-        /// <summary>
-        /// Adds the key and value to the parameters Collection
-        /// </summary>
-        /// <param name="key">The key to reference this value in the parameters collection.</param>
-        /// <param name="value">The value of the parameter to store</param>
-        void Add(string key, object value);
+    /// <param name="key">The key to reference this value in the parameters collection.</param>
+    /// <param name="value">The value of the parameter to store</param>
+    void Add(string key, object value);
 
-        /// <summary>
-        /// Checks collection for presence of key
-        /// </summary>
-        /// <param name="key">The key to check in the Collection</param>
-        /// <returns><c>true</c> if key exists; else returns <c>false</c>.</returns>
-        bool ContainsKey(string key);
+    /// <summary>
+    /// Checks collection for presence of key
+    /// </summary>
+    /// <param name="key">The key to check in the Collection</param>
+    /// <returns><c>true</c> if key exists; else returns <c>false</c>.</returns>
+    bool ContainsKey(string key);
 
-        /// <summary>
-        /// Returns the value of the member referenced by key
-        /// </summary>
-        /// <typeparam name="T">The type of object to be returned</typeparam>
-        /// <param name="key">The key for the value to be returned</param>
-        /// <returns>Returns a matching parameter of <typeparamref name="T"/> if one exists in the Collection</returns>
-        T GetValue<T>(string key);
-    }
+    /// <summary>
+    /// Returns the value of the member referenced by key
+    /// </summary>
+    /// <typeparam name="T">The type of object to be returned</typeparam>
+    /// <param name="key">The key for the value to be returned</param>
+    /// <returns>Returns a matching parameter of <typeparamref name="T"/> if one exists in the Collection</returns>
+    T GetValue<T>(string key);
 }

--- a/src/Prism.Maui/Navigation/INavigationResult.cs
+++ b/src/Prism.Maui/Navigation/INavigationResult.cs
@@ -1,9 +1,8 @@
-﻿namespace Prism.Navigation
-{
-    public interface INavigationResult
-    {
-        bool Success { get; }
+﻿namespace Prism.Navigation;
 
-        Exception Exception { get; }
-    }
+public interface INavigationResult
+{
+    bool Success { get; }
+
+    Exception Exception { get; }
 }

--- a/src/Prism.Maui/Navigation/INavigationService.cs
+++ b/src/Prism.Maui/Navigation/INavigationService.cs
@@ -1,35 +1,33 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// Provides page based navigation for ViewModels.
+/// </summary>
+public interface INavigationService
 {
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
+    Task<INavigationResult> GoBackAsync(INavigationParameters parameters);
 
     /// <summary>
-    /// Provides page based navigation for ViewModels.
+    /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
     /// </summary>
-    public interface INavigationService
-    {
-        /// <summary>
-        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-        Task<INavigationResult> GoBackAsync(INavigationParameters parameters);
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    /// <remarks>Only works when called from a View within a NavigationPage</remarks>
+    Task<INavigationResult> GoBackToRootAsync(INavigationParameters parameters);
 
-        /// <summary>
-        /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
-        /// </summary>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-        /// <remarks>Only works when called from a View within a NavigationPage</remarks>
-        Task<INavigationResult> GoBackToRootAsync(INavigationParameters parameters);
-
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="uri"/>.
-        /// </summary>
-        /// <param name="uri">The Uri to navigate to</param>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
-        /// <example>
-        /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
-        /// </example>
-        Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters);
-    }
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="uri"/>.
+    /// </summary>
+    /// <param name="uri">The Uri to navigate to</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
+    /// <example>
+    /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
+    /// </example>
+    Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters);
 }

--- a/src/Prism.Maui/Navigation/INavigationServiceExtensions.cs
+++ b/src/Prism.Maui/Navigation/INavigationServiceExtensions.cs
@@ -1,305 +1,303 @@
 ﻿using System.Text;
-using Microsoft.Maui.Controls;
 using Prism.Common;
 using Application = Microsoft.Maui.Controls.Application;
 
-namespace Prism.Navigation
+namespace Prism.Navigation;
+
+/// <summary>
+/// Common extensions for the <see cref="INavigationService"/>
+/// </summary>
+public static class INavigationServiceExtensions
 {
     /// <summary>
-    /// Common extensions for the <see cref="INavigationService"/>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
-    public static class INavigationServiceExtensions
+    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
+    public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService) =>
+        navigationService.GoBackAsync(null);
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
+    /// <param name="navigationService">Service for handling navigation between views</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService, params (string Key, object Value)[] parameters)
     {
-        /// <summary>
-        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-        /// </summary>
-        /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-        public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService) =>
-            navigationService.GoBackAsync(null);
+        return navigationService.GoBackAsync(GetNavigationParameters(parameters));
+    }
 
-        /// <summary>
-        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-        /// </summary>
-        /// <param name="navigationService">Service for handling navigation between views</param>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-        public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService, params (string Key, object Value)[] parameters)
+    /// <summary>
+    /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
+    /// </summary>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    /// <remarks>Only works when called from a View within a NavigationPage</remarks>
+    public static Task<INavigationResult> GoBackToRootAsync(this INavigationService navigationService) =>
+        navigationService.GoBackToRootAsync(null);
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="uri"/>.
+    /// </summary>
+    /// <param name="uri">The Uri to navigate to</param>
+    /// <example>
+    /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource));
+    /// </example>
+    public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, Uri uri) =>
+        navigationService.NavigateAsync(uri, null);
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="uri"/>.
+    /// </summary>
+    /// <param name="navigationService">Service for handling navigation between views</param>
+    /// <param name="uri">The Uri to navigate to</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
+    /// <example>
+    /// NavigateAsync(new Uri("MainPage?id=3&amp;name=dan", UriKind.RelativeSource), ("person", person), ("foo", bar));
+    /// </example>
+    public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, Uri uri, params (string Key, object Value)[] parameters)
+    {
+        return navigationService.NavigateAsync(uri, GetNavigationParameters(parameters));
+    }
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The name of the target to navigate to.</param>
+    public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name) =>
+        navigationService.NavigateAsync(name, default(INavigationParameters));
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The name of the target to navigate to.</param>
+    /// <param name="parameters">The navigation parameters</param>
+    public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, INavigationParameters parameters)
+    {
+        if (name.StartsWith(PageNavigationService.RemovePageRelativePath))
+            name = name.Replace(PageNavigationService.RemovePageRelativePath, PageNavigationService.RemovePageInstruction);
+
+        return navigationService.NavigateAsync(UriParsingHelper.Parse(name), parameters);
+    }
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="name"/>.
+    /// </summary>
+    /// <param name="navigationService">Service for handling navigation between views</param>
+    /// <param name="name">The Uri to navigate to</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
+    /// <example>
+    /// NavigateAsync("MainPage?id=3&amp;name=dan", ("person", person), ("foo", bar));
+    /// </example>
+    public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, params (string Key, object Value)[] parameters)
+    {
+        return navigationService.NavigateAsync(name, GetNavigationParameters(parameters));
+    }
+
+    /// <summary>
+    /// Provides an easy to use way to provide an Error Callback without using await NavigationService
+    /// </summary>
+    /// <param name="navigationTask">The current Navigation Task</param>
+    /// <param name="errorCallback">The <see cref="Exception"/> handler</param>
+    public static void OnNavigationError(this Task<INavigationResult> navigationTask, Action<Exception> errorCallback)
+    {
+        navigationTask.Await(r =>
         {
-            return navigationService.GoBackAsync(GetNavigationParameters(parameters));
+            if (!r.Success)
+                errorCallback?.Invoke(r.Exception);
+        });
+    }
+
+    /// <summary>
+    /// Gets an absolute path of the current page as it relates to it's position in the navigation stack.
+    /// </summary>
+    /// <returns>The absolute path of the current Page</returns>
+    public static string GetNavigationUriPath(this INavigationService navigationService)
+    {
+        var currentpage = ((IPageAware)navigationService).Page;
+
+        var stack = new Stack<string>();
+        currentpage = ProcessCurrentPageNavigationPath(currentpage, stack);
+        ProcessNavigationPath(currentpage, stack);
+
+        var sb = new StringBuilder();
+        while (stack.Count > 0)
+        {
+            sb.Append($"/{stack.Pop()}");
         }
+        return sb.ToString();
+    }
 
-        /// <summary>
-        /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
-        /// </summary>
-        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-        /// <remarks>Only works when called from a View within a NavigationPage</remarks>
-        public static Task<INavigationResult> GoBackToRootAsync(this INavigationService navigationService) =>
-            navigationService.GoBackToRootAsync(null);
-
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="uri"/>.
-        /// </summary>
-        /// <param name="uri">The Uri to navigate to</param>
-        /// <example>
-        /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource));
-        /// </example>
-        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, Uri uri) =>
-            navigationService.NavigateAsync(uri, null);
-
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="uri"/>.
-        /// </summary>
-        /// <param name="navigationService">Service for handling navigation between views</param>
-        /// <param name="uri">The Uri to navigate to</param>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-        /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
-        /// <example>
-        /// NavigateAsync(new Uri("MainPage?id=3&amp;name=dan", UriKind.RelativeSource), ("person", person), ("foo", bar));
-        /// </example>
-        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, Uri uri, params (string Key, object Value)[] parameters)
+    private static INavigationParameters GetNavigationParameters((string Key, object Value)[] parameters)
+    {
+        var navParams = new NavigationParameters();
+        foreach (var (Key, Value) in parameters)
         {
-            return navigationService.NavigateAsync(uri, GetNavigationParameters(parameters));
+            navParams.Add(Key, Value);
         }
+        return navParams;
+    }
 
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">The name of the target to navigate to.</param>
-        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name) =>
-            navigationService.NavigateAsync(name, default(INavigationParameters));
-
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">The name of the target to navigate to.</param>
-        /// <param name="parameters">The navigation parameters</param>
-        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, INavigationParameters parameters)
+    private static void ProcessNavigationPath(Page page, Stack<string> stack)
+    {
+        if (page.Parent is Page parent)
         {
-            if (name.StartsWith(PageNavigationService.RemovePageRelativePath))
-                name = name.Replace(PageNavigationService.RemovePageRelativePath, PageNavigationService.RemovePageInstruction);
-
-            return navigationService.NavigateAsync(UriParsingHelper.Parse(name), parameters);
-        }
-
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="name"/>.
-        /// </summary>
-        /// <param name="navigationService">Service for handling navigation between views</param>
-        /// <param name="name">The Uri to navigate to</param>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-        /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
-        /// <example>
-        /// NavigateAsync("MainPage?id=3&amp;name=dan", ("person", person), ("foo", bar));
-        /// </example>
-        public static Task<INavigationResult> NavigateAsync(this INavigationService navigationService, string name, params (string Key, object Value)[] parameters)
-        {
-            return navigationService.NavigateAsync(name, GetNavigationParameters(parameters));
-        }
-
-        /// <summary>
-        /// Provides an easy to use way to provide an Error Callback without using await NavigationService
-        /// </summary>
-        /// <param name="navigationTask">The current Navigation Task</param>
-        /// <param name="errorCallback">The <see cref="Exception"/> handler</param>
-        public static void OnNavigationError(this Task<INavigationResult> navigationTask, Action<Exception> errorCallback)
-        {
-            navigationTask.Await(r =>
+            if (parent is NavigationPage)
             {
-                if (!r.Success)
-                    errorCallback?.Invoke(r.Exception);
-            });
-        }
-
-        /// <summary>
-        /// Gets an absolute path of the current page as it relates to it's position in the navigation stack.
-        /// </summary>
-        /// <returns>The absolute path of the current Page</returns>
-        public static string GetNavigationUriPath(this INavigationService navigationService)
-        {
-            var currentpage = ((IPageAware)navigationService).Page;
-
-            var stack = new Stack<string>();
-            currentpage = ProcessCurrentPageNavigationPath(currentpage, stack);
-            ProcessNavigationPath(currentpage, stack);
-
-            var sb = new StringBuilder();
-            while (stack.Count > 0)
-            {
-                sb.Append($"/{stack.Pop()}");
-            }
-            return sb.ToString();
-        }
-
-        private static INavigationParameters GetNavigationParameters((string Key, object Value)[] parameters)
-        {
-            var navParams = new NavigationParameters();
-            foreach (var (Key, Value) in parameters)
-            {
-                navParams.Add(Key, Value);
-            }
-            return navParams;
-        }
-
-        private static void ProcessNavigationPath(Page page, Stack<string> stack)
-        {
-            if (page.Parent is Page parent)
-            {
-                if (parent is NavigationPage)
+                var index = PageUtilities.GetCurrentPageIndex(page, page.Navigation.NavigationStack);
+                if (index > 0)
                 {
-                    var index = PageUtilities.GetCurrentPageIndex(page, page.Navigation.NavigationStack);
-                    if (index > 0)
+                    int previousPageIndex = index - 1;
+                    for (int x = previousPageIndex; x >= 0; x--)
                     {
-                        int previousPageIndex = index - 1;
-                        for (int x = previousPageIndex; x >= 0; x--)
-                        {
-                            AddSegmentToStack(page.Navigation.NavigationStack[x], stack);
-                        }
+                        AddSegmentToStack(page.Navigation.NavigationStack[x], stack);
                     }
-
-                    AddSegmentToStack(parent, stack);
-                }
-                else if (parent is FlyoutPage)
-                {
-                    AddSegmentToStack(parent, stack);
                 }
 
-                ProcessNavigationPath(parent, stack);
+                AddSegmentToStack(parent, stack);
             }
-            else
+            else if (parent is FlyoutPage)
             {
-                ProcessModalNavigation(page, stack);
+                AddSegmentToStack(parent, stack);
             }
+
+            ProcessNavigationPath(parent, stack);
         }
-
-        private static void ProcessModalNavigation(Page page, Stack<string> stack)
+        else
         {
-            var index = PageUtilities.GetCurrentPageIndex(page, page.Navigation.ModalStack);
-            int previousPageIndex = index - 1;
-            for (int x = previousPageIndex; x >= 0; x--)
-            {
-                var childPage = page.Navigation.ModalStack[x];
-                if (childPage is NavigationPage navigationPage)
-                {
-                    AddUseModalNavigationParameter(stack);
-                    ProcessModalNavigationPagePath(navigationPage, stack);
-                }
-                else if (childPage is FlyoutPage flyout)
-                {
-                    ProcessModalFlyoutPagePath(flyout, stack);
-                }
-                else
-                {
-                    AddSegmentToStack(childPage, stack);
-                }
-            }
-
-            ProcessMainPagePath(Application.Current?.MainPage, page, stack);
+            ProcessModalNavigation(page, stack);
         }
+    }
 
-        private static void ProcessMainPagePath(Page mainPage, Page previousPage, Stack<string> stack)
+    private static void ProcessModalNavigation(Page page, Stack<string> stack)
+    {
+        var index = PageUtilities.GetCurrentPageIndex(page, page.Navigation.ModalStack);
+        int previousPageIndex = index - 1;
+        for (int x = previousPageIndex; x >= 0; x--)
         {
-            if (mainPage == null)
-                return;
-
-            if (previousPage == mainPage)
-                return;
-
-            if (mainPage is NavigationPage mainPageAsNavigationPage)
-            {
-                AddUseModalNavigationParameter(stack);
-                ProcessModalNavigationPagePath(mainPageAsNavigationPage, stack);
-            }
-            else if (mainPage is FlyoutPage flyout)
-            {
-                var detail = flyout.Detail;
-                if (detail is NavigationPage detailAsNavigationPage)
-                {
-                    AddUseModalNavigationParameter(stack);
-                    ProcessModalNavigationPagePath(detailAsNavigationPage, stack);
-                }
-                else
-                {
-                    AddSegmentToStack(detail, stack);
-                }
-
-                AddSegmentToStack(mainPage, stack);
-            }
-            else
-            {
-                AddSegmentToStack(mainPage, stack);
-            }
-        }
-
-        private static void ProcessModalNavigationPagePath(NavigationPage page, Stack<string> stack)
-        {
-            var navStack = page.Navigation.NavigationStack.Reverse();
-            foreach (var child in navStack)
-            {
-                AddSegmentToStack(child, stack);
-            }
-
-            AddSegmentToStack(page, stack);
-        }
-
-        private static void ProcessModalFlyoutPagePath(FlyoutPage page, Stack<string> stack)
-        {
-            if (page.Detail is NavigationPage navigationPage)
+            var childPage = page.Navigation.ModalStack[x];
+            if (childPage is NavigationPage navigationPage)
             {
                 AddUseModalNavigationParameter(stack);
                 ProcessModalNavigationPagePath(navigationPage, stack);
             }
+            else if (childPage is FlyoutPage flyout)
+            {
+                ProcessModalFlyoutPagePath(flyout, stack);
+            }
             else
             {
-                AddSegmentToStack(page.Detail, stack);
+                AddSegmentToStack(childPage, stack);
             }
-
-            AddSegmentToStack(page, stack);
         }
 
-        private static Page ProcessCurrentPageNavigationPath(Page page, Stack<string> stack)
-        {
-            var currentPageKeyInfo = NavigationRegistry.GetPageNavigationInfo(page.GetType());
-            string currentSegment = $"{currentPageKeyInfo.Name}";
+        ProcessMainPagePath(Application.Current?.MainPage, page, stack);
+    }
 
-            if (page.Parent is Page parent)
+    private static void ProcessMainPagePath(Page mainPage, Page previousPage, Stack<string> stack)
+    {
+        if (mainPage == null)
+            return;
+
+        if (previousPage == mainPage)
+            return;
+
+        if (mainPage is NavigationPage mainPageAsNavigationPage)
+        {
+            AddUseModalNavigationParameter(stack);
+            ProcessModalNavigationPagePath(mainPageAsNavigationPage, stack);
+        }
+        else if (mainPage is FlyoutPage flyout)
+        {
+            var detail = flyout.Detail;
+            if (detail is NavigationPage detailAsNavigationPage)
             {
-                var parentKeyInfo = NavigationRegistry.GetPageNavigationInfo(parent.GetType());
-
-                if (parent is TabbedPage)
-                {
-                    //set the selected tab to the current page
-                    currentSegment = $"{parentKeyInfo.Name}?{KnownNavigationParameters.SelectedTab}={currentPageKeyInfo.Name}";
-                    page = parent;
-                }
-                else if (parent is FlyoutPage)
-                {
-                    currentSegment = $"{parentKeyInfo.Name}/{currentPageKeyInfo.Name}";
-                    page = parent;
-                }
+                AddUseModalNavigationParameter(stack);
+                ProcessModalNavigationPagePath(detailAsNavigationPage, stack);
+            }
+            else
+            {
+                AddSegmentToStack(detail, stack);
             }
 
-            stack.Push(currentSegment);
-
-            return page;
+            AddSegmentToStack(mainPage, stack);
         }
-
-        private static void AddSegmentToStack(Page page, Stack<string> stack)
+        else
         {
-            if (page == null)
-                return;
-
-            var keyInfo = NavigationRegistry.GetPageNavigationInfo(page.GetType());
-            if (keyInfo != null)
-                stack.Push(keyInfo.Name);
+            AddSegmentToStack(mainPage, stack);
         }
+    }
 
-        private static void AddUseModalNavigationParameter(Stack<string> stack)
+    private static void ProcessModalNavigationPagePath(NavigationPage page, Stack<string> stack)
+    {
+        var navStack = page.Navigation.NavigationStack.Reverse();
+        foreach (var child in navStack)
         {
-            var lastPageName = stack.Pop();
-            lastPageName = $"{lastPageName}?{KnownNavigationParameters.UseModalNavigation}=true";
-            stack.Push(lastPageName);
+            AddSegmentToStack(child, stack);
         }
+
+        AddSegmentToStack(page, stack);
+    }
+
+    private static void ProcessModalFlyoutPagePath(FlyoutPage page, Stack<string> stack)
+    {
+        if (page.Detail is NavigationPage navigationPage)
+        {
+            AddUseModalNavigationParameter(stack);
+            ProcessModalNavigationPagePath(navigationPage, stack);
+        }
+        else
+        {
+            AddSegmentToStack(page.Detail, stack);
+        }
+
+        AddSegmentToStack(page, stack);
+    }
+
+    private static Page ProcessCurrentPageNavigationPath(Page page, Stack<string> stack)
+    {
+        var currentPageKeyInfo = NavigationRegistry.GetPageNavigationInfo(page.GetType());
+        string currentSegment = $"{currentPageKeyInfo.Name}";
+
+        if (page.Parent is Page parent)
+        {
+            var parentKeyInfo = NavigationRegistry.GetPageNavigationInfo(parent.GetType());
+
+            if (parent is TabbedPage)
+            {
+                //set the selected tab to the current page
+                currentSegment = $"{parentKeyInfo.Name}?{KnownNavigationParameters.SelectedTab}={currentPageKeyInfo.Name}";
+                page = parent;
+            }
+            else if (parent is FlyoutPage)
+            {
+                currentSegment = $"{parentKeyInfo.Name}/{currentPageKeyInfo.Name}";
+                page = parent;
+            }
+        }
+
+        stack.Push(currentSegment);
+
+        return page;
+    }
+
+    private static void AddSegmentToStack(Page page, Stack<string> stack)
+    {
+        if (page == null)
+            return;
+
+        var keyInfo = NavigationRegistry.GetPageNavigationInfo(page.GetType());
+        if (keyInfo != null)
+            stack.Push(keyInfo.Name);
+    }
+
+    private static void AddUseModalNavigationParameter(Stack<string> stack)
+    {
+        var lastPageName = stack.Pop();
+        lastPageName = $"{lastPageName}?{KnownNavigationParameters.UseModalNavigation}=true";
+        stack.Push(lastPageName);
     }
 }

--- a/src/Prism.Maui/Navigation/KnownInternalParameters.cs
+++ b/src/Prism.Maui/Navigation/KnownInternalParameters.cs
@@ -1,7 +1,6 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+internal static class KnownInternalParameters
 {
-    internal static class KnownInternalParameters
-    {
-        public const string NavigationMode = "__NavigationMode";
-    }
+    public const string NavigationMode = "__NavigationMode";
 }

--- a/src/Prism.Maui/Navigation/KnownNavigationParameters.cs
+++ b/src/Prism.Maui/Navigation/KnownNavigationParameters.cs
@@ -1,25 +1,24 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+public static class KnownNavigationParameters
 {
-    public static class KnownNavigationParameters
-    {
-        /// <summary>
-        /// Used to dynamically create a Page that will be used as a Tab when navigating to a TabbedPage.
-        /// </summary>
-        public const string CreateTab = "createTab";
+    /// <summary>
+    /// Used to dynamically create a Page that will be used as a Tab when navigating to a TabbedPage.
+    /// </summary>
+    public const string CreateTab = "createTab";
 
-        /// <summary>
-        /// Used to select an existing Tab when navigating to a TabbedPage.
-        /// </summary>
-        public const string SelectedTab = "selectedTab";
+    /// <summary>
+    /// Used to select an existing Tab when navigating to a TabbedPage.
+    /// </summary>
+    public const string SelectedTab = "selectedTab";
 
-        /// <summary>
-        /// Used to control the navigation stack. If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync.
-        /// </summary>
-        public const string UseModalNavigation = "useModalNavigation";
+    /// <summary>
+    /// Used to control the navigation stack. If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync.
+    /// </summary>
+    public const string UseModalNavigation = "useModalNavigation";
 
-        /// <summary>
-        /// Used to define a navigation parameter that is bound directly to a CommandParameter via <code>{Binding .}</code>.
-        /// </summary>
-        public const string XamlParam = "xamlParam";
-    }
+    /// <summary>
+    /// Used to define a navigation parameter that is bound directly to a CommandParameter via <code>{Binding .}</code>.
+    /// </summary>
+    public const string XamlParam = "xamlParam";
 }

--- a/src/Prism.Maui/Navigation/NavigationException.cs
+++ b/src/Prism.Maui/Navigation/NavigationException.cs
@@ -1,31 +1,53 @@
-using Microsoft.Maui.Controls;
+namespace Prism.Navigation;
 
-namespace Prism.Navigation
+public class NavigationException : Exception
 {
-    public class NavigationException : Exception
+    public const string CannotPopApplicationMainPage = "Cannot Pop Application MainPage";
+    public const string CannotGoBackFromRoot = "Cannot GoBack from NavigationPage Root.";
+    public const string GoBackToRootRequiresNavigationPage = "GoBackToRootAsync can only be called when the calling Page is within a NavigationPage.";
+    public const string RelativeNavigationRequiresNavigationPage = "Removing views using the relative '../' syntax while navigating is only supported within a NavigationPage";
+    public const string IConfirmNavigationReturnedFalse = "IConfirmNavigation returned false";
+    public const string NoPageIsRegistered = "No Page has been registered with the provided key";
+    public const string ErrorCreatingPage = "An error occurred while resolving the page. This is most likely the result of invalid XAML or other type initialization exception";
+    public const string MvvmPatternBreak = "You have referenced a View type and are likely breaking the MVVM pattern. You should never reference a View type from a ViewModel.";
+    public const string UnknownException = "An unknown error occurred. You may need to specify whether to Use Modal Navigation or not.";
+
+    public NavigationException()
     {
-        public const string CannotPopApplicationMainPage = "Cannot Pop Application MainPage";
-        public const string CannotGoBackFromRoot = "Cannot GoBack from NavigationPage Root.";
-        public const string GoBackToRootRequiresNavigationPage = "GoBackToRootAsync can only be called when the calling Page is within a NavigationPage.";
-        public const string RelativeNavigationRequiresNavigationPage = "Removing views using the relative '../' syntax while navigating is only supported within a NavigationPage";
-        public const string IConfirmNavigationReturnedFalse = "IConfirmNavigation returned false";
-        public const string NoPageIsRegistered = "No Page has been registered with the provided key";
-        public const string ErrorCreatingPage = "An error occurred while resolving the page. This is most likely the result of invalid XAML or other type initialization exception";
-        public const string UnknownException = "An unknown error occurred. You may need to specify whether to Use Modal Navigation or not.";
-
-        public NavigationException()
-        {
-        }
-
-        public NavigationException(string message, Page page) : this(message, page, null)
-        {
-        }
-
-        public NavigationException(string message, Page page, Exception innerException) : base(message, innerException)
-        {
-            Page = page;
-        }
-
-        public Page Page { get; }
     }
+
+    public NavigationException(string message)
+        : this(message, null, null, null)
+    {
+    }
+
+    public NavigationException(string message, Page page)
+        : this(message, page, null)
+    {
+    }
+
+    public NavigationException(string message, string navigationKey)
+        : this(message, navigationKey, null, null)
+    {
+    }
+
+    public NavigationException(string message, string navigationKey, Exception innerException)
+        : this(message, navigationKey, null, innerException)
+    {
+    }
+
+    public NavigationException(string message, Page page, Exception innerException) 
+        : this(message, null, page, innerException)
+    {
+    }
+
+    public NavigationException(string message, string navigationKey, Page page, Exception innerException) : base(message, innerException)
+    {
+        Page = page;
+        NavigationKey = navigationKey;
+    }
+
+    public Page Page { get; }
+
+    public string NavigationKey { get; }
 }

--- a/src/Prism.Maui/Navigation/NavigationMode.cs
+++ b/src/Prism.Maui/Navigation/NavigationMode.cs
@@ -1,17 +1,16 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+/// <summary>
+/// The NavigationMode provides information about the navigation operation that has been invoked.
+/// </summary>
+public enum NavigationMode
 {
     /// <summary>
-    /// The NavigationMode provides information about the navigation operation that has been invoked.
+    /// Indicates that a navigation operation occured that resulted in navigating backwards in the navigation stack.
     /// </summary>
-    public enum NavigationMode
-    {
-        /// <summary>
-        /// Indicates that a navigation operation occured that resulted in navigating backwards in the navigation stack.
-        /// </summary>
-        Back,
-        /// <summary>
-        /// Indicates that a new navigation operation has occured and a new page has been added to the navigation stack.
-        /// </summary>
-        New,
-    }
+    Back,
+    /// <summary>
+    /// Indicates that a new navigation operation has occured and a new page has been added to the navigation stack.
+    /// </summary>
+    New,
 }

--- a/src/Prism.Maui/Navigation/NavigationParameters.cs
+++ b/src/Prism.Maui/Navigation/NavigationParameters.cs
@@ -1,48 +1,47 @@
 ﻿using Prism.Common;
 
-namespace Prism.Navigation
+namespace Prism.Navigation;
+
+/// <summary>
+/// Represents Navigation parameters.
+/// </summary>
+/// <remarks>
+/// This class can be used to to pass object parameters during Navigation. 
+/// </remarks>
+public class NavigationParameters : ParametersBase, INavigationParameters, INavigationParametersInternal
 {
+    private readonly Dictionary<string, object> _internalParameters = new Dictionary<string, object>();
+
     /// <summary>
-    /// Represents Navigation parameters.
+    /// Initializes a new instance of the <see cref="NavigationParameters"/> class.
     /// </summary>
-    /// <remarks>
-    /// This class can be used to to pass object parameters during Navigation. 
-    /// </remarks>
-    public class NavigationParameters : ParametersBase, INavigationParameters, INavigationParametersInternal
+    public NavigationParameters()
     {
-        private readonly Dictionary<string, object> _internalParameters = new Dictionary<string, object>();
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NavigationParameters"/> class.
-        /// </summary>
-        public NavigationParameters()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NavigationParameters"/> class with a query string.
-        /// </summary>
-        /// <param name="query">The query string.</param>
-        public NavigationParameters(string query)
-            : base(query)
-        {
-        }
-
-        #region INavigationParametersInternal
-        void INavigationParametersInternal.Add(string key, object value)
-        {
-            _internalParameters.Add(key, value);
-        }
-
-        bool INavigationParametersInternal.ContainsKey(string key)
-        {
-            return _internalParameters.ContainsKey(key);
-        }
-
-        T INavigationParametersInternal.GetValue<T>(string key)
-        {
-            return _internalParameters.GetValue<T>(key);
-        }
-        #endregion
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NavigationParameters"/> class with a query string.
+    /// </summary>
+    /// <param name="query">The query string.</param>
+    public NavigationParameters(string query)
+        : base(query)
+    {
+    }
+
+    #region INavigationParametersInternal
+    void INavigationParametersInternal.Add(string key, object value)
+    {
+        _internalParameters.Add(key, value);
+    }
+
+    bool INavigationParametersInternal.ContainsKey(string key)
+    {
+        return _internalParameters.ContainsKey(key);
+    }
+
+    T INavigationParametersInternal.GetValue<T>(string key)
+    {
+        return _internalParameters.GetValue<T>(key);
+    }
+    #endregion
 }

--- a/src/Prism.Maui/Navigation/NavigationParametersExtensions.cs
+++ b/src/Prism.Maui/Navigation/NavigationParametersExtensions.cs
@@ -1,21 +1,20 @@
 ﻿using Prism.Properties;
 
-namespace Prism.Navigation
+namespace Prism.Navigation;
+
+public static class NavigationParametersExtensions
 {
-    public static class NavigationParametersExtensions
+    public static NavigationMode GetNavigationMode(this INavigationParameters parameters)
     {
-        public static NavigationMode GetNavigationMode(this INavigationParameters parameters)
-        {
-            var internalParams = (INavigationParametersInternal)parameters;
-            if (internalParams.ContainsKey(KnownInternalParameters.NavigationMode))
-                return internalParams.GetValue<NavigationMode>(KnownInternalParameters.NavigationMode);
+        var internalParams = (INavigationParametersInternal)parameters;
+        if (internalParams.ContainsKey(KnownInternalParameters.NavigationMode))
+            return internalParams.GetValue<NavigationMode>(KnownInternalParameters.NavigationMode);
 
-            throw new System.ArgumentNullException(Resources.NavigationModeNotAvailable);
-        }
+        throw new System.ArgumentNullException(Resources.NavigationModeNotAvailable);
+    }
 
-        internal static INavigationParametersInternal GetNavigationParametersInternal(this INavigationParameters parameters)
-        {
-            return (INavigationParametersInternal)parameters;
-        }
+    internal static INavigationParametersInternal GetNavigationParametersInternal(this INavigationParameters parameters)
+    {
+        return (INavigationParametersInternal)parameters;
     }
 }

--- a/src/Prism.Maui/Navigation/NavigationRegistry.cs
+++ b/src/Prism.Maui/Navigation/NavigationRegistry.cs
@@ -13,6 +13,8 @@ public static class NavigationRegistry
 {
     private static readonly List<ViewRegistration> _registrations = new ();
 
+    internal static IEnumerable<ViewRegistration> Registrations => _registrations;
+
     public static void Register<TView, TViewModel>(string name) =>
         Register(typeof(TView), typeof(TViewModel), name);
 

--- a/src/Prism.Maui/Navigation/NavigationResult.cs
+++ b/src/Prism.Maui/Navigation/NavigationResult.cs
@@ -1,9 +1,8 @@
-﻿namespace Prism.Navigation
-{
-    public record NavigationResult : INavigationResult
-    {
-        public bool Success { get; init; }
+﻿namespace Prism.Navigation;
 
-        public Exception Exception { get; init; }
-    }
+public record NavigationResult : INavigationResult
+{
+    public bool Success { get; init; }
+
+    public Exception Exception { get; init; }
 }

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -3,1105 +3,1104 @@ using Prism.Common;
 using Prism.Ioc;
 using Application = Microsoft.Maui.Controls.Application;
 
-namespace Prism.Navigation
+namespace Prism.Navigation;
+
+/// <summary>
+/// Provides page based navigation for ViewModels.
+/// </summary>
+public class PageNavigationService : INavigationService, IPageAware
 {
-    /// <summary>
-    /// Provides page based navigation for ViewModels.
-    /// </summary>
-    public class PageNavigationService : INavigationService, IPageAware
+    internal const string RemovePageRelativePath = "../";
+    internal const string RemovePageInstruction = "__RemovePage/";
+    internal const string RemovePageSegment = "__RemovePage";
+
+    // TODO: Move this out of the PageNavigationService
+    internal static PageNavigationSource NavigationSource { get; set; } = PageNavigationSource.Device;
+
+    private readonly IContainerProvider _container;
+    protected readonly IApplication _application;
+    protected Window Window;
+
+    protected Page _page;
+    Page IPageAware.Page
     {
-        internal const string RemovePageRelativePath = "../";
-        internal const string RemovePageInstruction = "__RemovePage/";
-        internal const string RemovePageSegment = "__RemovePage";
-
-        // TODO: Move this out of the PageNavigationService
-        internal static PageNavigationSource NavigationSource { get; set; } = PageNavigationSource.Device;
-
-        private readonly IContainerProvider _container;
-        protected readonly IApplication _application;
-        protected Window Window;
-
-        protected Page _page;
-        Page IPageAware.Page
+        get
         {
-            get
+            if(Window is null)
             {
-                if(Window is null)
+                Element curPage = _page;
+                while (curPage?.Parent != null)
                 {
-                    Element curPage = _page;
-                    while (curPage?.Parent != null)
-                    {
-                        if (curPage.Parent is Window window)
-                            Window = window;
-                        curPage = curPage.Parent;
-                    }
-                }
-
-                return _page;
-            }
-            set => _page = value;
-        }
-
-        /// <summary>
-        /// Constructs a new instance of the <see cref="PageNavigationService"/>.
-        /// </summary>
-        /// <param name="container">The <see cref="IContainerProvider"/> that will be used to resolve pages for navigation.</param>
-        /// <param name="application">The <see cref="IApplication"/> that will let us ensure the Application.MainPage is set.</param>
-        /// <param name="pageBehaviorFactory">The <see cref="IPageBehaviorFactory"/> that will apply base and custom behaviors to pages created in the <see cref="PageNavigationService"/>.</param>
-        public PageNavigationService(IContainerProvider container, IApplication application)
-        {
-            _container = container;
-            _application = application;
-        }
-
-        /// <summary>
-        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-        /// </summary>
-        /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-        public virtual Task<INavigationResult> GoBackAsync()
-        {
-            return GoBackAsync(null);
-        }
-
-        /// <summary>
-        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-        public virtual Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
-        {
-            return GoBackInternal(parameters, null, true);
-        }
-
-        /// <summary>
-        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-        /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-        public virtual Task<INavigationResult> GoBackAsync(INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            return GoBackInternal(parameters, useModalNavigation, animated);
-        }
-
-        /// <summary>
-        /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-        /// </summary>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-        /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-        protected async virtual Task<INavigationResult> GoBackInternal(INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            Page page = null;
-            try
-            {
-                NavigationSource = PageNavigationSource.NavigationService;
-
-                page = GetCurrentPage();
-                if (IsRoot(GetPageFromWindow(), page))
-                    throw new NavigationException(NavigationException.CannotPopApplicationMainPage, page);
-
-                var segmentParameters = UriParsingHelper.GetSegmentParameters(null, parameters);
-                segmentParameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
-
-                var canNavigate = await PageUtilities.CanNavigateAsync(page, segmentParameters);
-                if (!canNavigate)
-                {
-                    return new NavigationResult
-                    {
-                        Exception = new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, page)
-                    };
-                }
-
-                bool useModalForDoPop = UseModalGoBack(page, useModalNavigation);
-                Page previousPage = PageUtilities.GetOnNavigatedToTarget(page, Window?.Page, useModalForDoPop);
-
-                var poppedPage = await DoPop(page.Navigation, useModalForDoPop, animated);
-                if (poppedPage != null)
-                {
-                    PageUtilities.OnNavigatedFrom(page, segmentParameters);
-                    PageUtilities.OnNavigatedTo(previousPage, segmentParameters);
-                    PageUtilities.DestroyPage(poppedPage);
-
-                    return new NavigationResult { Success = true };
+                    if (curPage.Parent is Window window)
+                        Window = window;
+                    curPage = curPage.Parent;
                 }
             }
-            catch (Exception ex)
-            {
-                return new NavigationResult { Exception = ex };
-            }
-            finally
-            {
-                NavigationSource = PageNavigationSource.Device;
-            }
 
-            return new NavigationResult
-            {
-                Exception = GetGoBackException(page, GetPageFromWindow())
-            };
+            return _page;
         }
+        set => _page = value;
+    }
 
-        private static Exception GetGoBackException(Page currentPage, IView mainPage)
+    /// <summary>
+    /// Constructs a new instance of the <see cref="PageNavigationService"/>.
+    /// </summary>
+    /// <param name="container">The <see cref="IContainerProvider"/> that will be used to resolve pages for navigation.</param>
+    /// <param name="application">The <see cref="IApplication"/> that will let us ensure the Application.MainPage is set.</param>
+    /// <param name="pageBehaviorFactory">The <see cref="IPageBehaviorFactory"/> that will apply base and custom behaviors to pages created in the <see cref="PageNavigationService"/>.</param>
+    public PageNavigationService(IContainerProvider container, IApplication application)
+    {
+        _container = container;
+        _application = application;
+    }
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
+    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
+    public virtual Task<INavigationResult> GoBackAsync()
+    {
+        return GoBackAsync(null);
+    }
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
+    public virtual Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
+    {
+        return GoBackInternal(parameters, null, true);
+    }
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
+    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    public virtual Task<INavigationResult> GoBackAsync(INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        return GoBackInternal(parameters, useModalNavigation, animated);
+    }
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
+    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
+    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
+    protected async virtual Task<INavigationResult> GoBackInternal(INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        Page page = null;
+        try
         {
-            if (IsMainPage(currentPage, mainPage))
+            NavigationSource = PageNavigationSource.NavigationService;
+
+            page = GetCurrentPage();
+            if (IsRoot(GetPageFromWindow(), page))
+                throw new NavigationException(NavigationException.CannotPopApplicationMainPage, page);
+
+            var segmentParameters = UriParsingHelper.GetSegmentParameters(null, parameters);
+            segmentParameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
+
+            var canNavigate = await PageUtilities.CanNavigateAsync(page, segmentParameters);
+            if (!canNavigate)
             {
-                return new NavigationException(NavigationException.CannotPopApplicationMainPage, currentPage);
-            }
-            else if ((currentPage is NavigationPage navPage && IsOnNavigationPageRoot(navPage)) ||
-                (currentPage.Parent is NavigationPage navParent && IsOnNavigationPageRoot(navParent)))
-            {
-                return new NavigationException(NavigationException.CannotGoBackFromRoot, currentPage);
-            }
-
-            return new NavigationException(NavigationException.UnknownException, currentPage);
-        }
-
-        private static bool IsOnNavigationPageRoot(NavigationPage navigationPage) =>
-            navigationPage.CurrentPage == navigationPage.RootPage;
-
-        private static bool IsMainPage(IView currentPage, IView mainPage)
-        {
-            if (currentPage == mainPage)
-            {
-                return true;
-            }
-            else if (mainPage is FlyoutPage flyout && flyout.Detail == currentPage)
-            {
-                return true;
-            }
-            else if (currentPage.Parent is TabbedPage tabbed && mainPage == tabbed)
-            {
-                return true;
-            }
-            else if (currentPage.Parent is NavigationPage navPage && navPage.CurrentPage == navPage.RootPage)
-            {
-                return IsMainPage(navPage, mainPage);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
-        /// </summary>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-        /// <remarks>Only works when called from a View within a NavigationPage</remarks>
-        public virtual Task<INavigationResult> GoBackToRootAsync(INavigationParameters parameters)
-        {
-            return GoBackToRootInternal(parameters);
-        }
-
-        /// <summary>
-        /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
-        /// </summary>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <remarks>Only works when called from a View within a NavigationPage</remarks>
-        protected async virtual Task<INavigationResult> GoBackToRootInternal(INavigationParameters parameters)
-        {
-            try
-            {
-                if (parameters is null)
-                    parameters = new NavigationParameters();
-
-                parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
-
-                var page = GetCurrentPage();
-                var canNavigate = await PageUtilities.CanNavigateAsync(page, parameters);
-                if (!canNavigate)
+                return new NavigationResult
                 {
-                    return new NavigationResult
-                    {
-                        Exception = new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, page)
-                    };
-                }
+                    Exception = new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, page)
+                };
+            }
 
-                var pagesToDestroy = page.Navigation.NavigationStack.ToList(); // get all pages to destroy
-                pagesToDestroy.Reverse(); // destroy them in reverse order
-                var root = pagesToDestroy.Last();
-                pagesToDestroy.Remove(root); //don't destroy the root page
+            bool useModalForDoPop = UseModalGoBack(page, useModalNavigation);
+            Page previousPage = PageUtilities.GetOnNavigatedToTarget(page, Window?.Page, useModalForDoPop);
 
-                await page.Navigation.PopToRootAsync();
-
-                foreach (var destroyPage in pagesToDestroy)
-                {
-                    PageUtilities.OnNavigatedFrom(destroyPage, parameters);
-                    PageUtilities.DestroyPage(destroyPage);
-                }
-
-                PageUtilities.OnNavigatedTo(root, parameters);
+            var poppedPage = await DoPop(page.Navigation, useModalForDoPop, animated);
+            if (poppedPage != null)
+            {
+                PageUtilities.OnNavigatedFrom(page, segmentParameters);
+                PageUtilities.OnNavigatedTo(previousPage, segmentParameters);
+                PageUtilities.DestroyPage(poppedPage);
 
                 return new NavigationResult { Success = true };
             }
-            catch (Exception ex)
-            {
-                return new NavigationResult { Exception = ex };
-            }
+        }
+        catch (Exception ex)
+        {
+            return new NavigationResult { Exception = ex };
+        }
+        finally
+        {
+            NavigationSource = PageNavigationSource.Device;
         }
 
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">The name of the target to navigate to.</param>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-        /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        protected virtual Task<INavigationResult> NavigateInternal(string name, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+        return new NavigationResult
         {
-            if (name.StartsWith(RemovePageRelativePath))
-            {
-                name = name.Replace(RemovePageRelativePath, RemovePageInstruction);
-            }
+            Exception = GetGoBackException(page, GetPageFromWindow())
+        };
+    }
 
-            return NavigateInternal(UriParsingHelper.Parse(name), parameters, useModalNavigation, animated);
+    private static Exception GetGoBackException(Page currentPage, IView mainPage)
+    {
+        if (IsMainPage(currentPage, mainPage))
+        {
+            return new NavigationException(NavigationException.CannotPopApplicationMainPage, currentPage);
+        }
+        else if ((currentPage is NavigationPage navPage && IsOnNavigationPageRoot(navPage)) ||
+            (currentPage.Parent is NavigationPage navParent && IsOnNavigationPageRoot(navParent)))
+        {
+            return new NavigationException(NavigationException.CannotGoBackFromRoot, currentPage);
         }
 
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="uri"/>.
-        /// </summary>
-        /// <param name="uri">The Uri to navigate to</param>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
-        /// <example>
-        /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
-        /// </example>
-        public virtual Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters)
+        return new NavigationException(NavigationException.UnknownException, currentPage);
+    }
+
+    private static bool IsOnNavigationPageRoot(NavigationPage navigationPage) =>
+        navigationPage.CurrentPage == navigationPage.RootPage;
+
+    private static bool IsMainPage(IView currentPage, IView mainPage)
+    {
+        if (currentPage == mainPage)
         {
-            return NavigateInternal(uri, parameters, null, true);
+            return true;
+        }
+        else if (mainPage is FlyoutPage flyout && flyout.Detail == currentPage)
+        {
+            return true;
+        }
+        else if (currentPage.Parent is TabbedPage tabbed && mainPage == tabbed)
+        {
+            return true;
+        }
+        else if (currentPage.Parent is NavigationPage navPage && navPage.CurrentPage == navPage.RootPage)
+        {
+            return IsMainPage(navPage, mainPage);
         }
 
-        /// <summary>
-        /// Initiates navigation to the target specified by the <paramref name="uri"/>.
-        /// </summary>
-        /// <param name="uri">The Uri to navigate to</param>
-        /// <param name="parameters">The navigation parameters</param>
-        /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-        /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-        /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
-        /// <example>
-        /// Navigate(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
-        /// </example>
-        protected async virtual Task<INavigationResult> NavigateInternal(Uri uri, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+        return false;
+    }
+
+    /// <summary>
+    /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
+    /// </summary>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    /// <remarks>Only works when called from a View within a NavigationPage</remarks>
+    public virtual Task<INavigationResult> GoBackToRootAsync(INavigationParameters parameters)
+    {
+        return GoBackToRootInternal(parameters);
+    }
+
+    /// <summary>
+    /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
+    /// </summary>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <remarks>Only works when called from a View within a NavigationPage</remarks>
+    protected async virtual Task<INavigationResult> GoBackToRootInternal(INavigationParameters parameters)
+    {
+        try
         {
-            try
+            if (parameters is null)
+                parameters = new NavigationParameters();
+
+            parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
+
+            var page = GetCurrentPage();
+            var canNavigate = await PageUtilities.CanNavigateAsync(page, parameters);
+            if (!canNavigate)
             {
-                NavigationSource = PageNavigationSource.NavigationService;
-
-                var navigationSegments = UriParsingHelper.GetUriSegments(uri);
-
-                if (uri.IsAbsoluteUri)
+                return new NavigationResult
                 {
-                    await ProcessNavigationForAbsoluteUri(navigationSegments, parameters, useModalNavigation, animated);
-                    return new NavigationResult { Success = true };
-                }
-                else
-                {
-                    await ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, animated);
-                    return new NavigationResult { Success = true };
-                }
-            }
-            catch (Exception ex)
-            {
-                return new NavigationResult { Exception = ex };
-            }
-            finally
-            {
-                NavigationSource = PageNavigationSource.Device;
-            }
-        }
-
-        /// <summary>
-        /// Processes the Navigation for the Queued navigation segments
-        /// </summary>
-        /// <param name="currentPage">The Current <see cref="Page"/> that we are navigating from.</param>
-        /// <param name="segments">The Navigation <see cref="Uri"/> segments.</param>
-        /// <param name="parameters">The <see cref="INavigationParameters"/>.</param>
-        /// <param name="useModalNavigation"><see cref="Nullable{Boolean}"/> flag if we should force Modal Navigation.</param>
-        /// <param name="animated">If <c>true</c>, the navigation will be animated.</param>
-        /// <returns></returns>
-        protected virtual async Task ProcessNavigation(Page currentPage, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            if (segments.Count == 0)
-            {
-                return;
+                    Exception = new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, page)
+                };
             }
 
-            var nextSegment = segments.Dequeue();
+            var pagesToDestroy = page.Navigation.NavigationStack.ToList(); // get all pages to destroy
+            pagesToDestroy.Reverse(); // destroy them in reverse order
+            var root = pagesToDestroy.Last();
+            pagesToDestroy.Remove(root); //don't destroy the root page
 
-            var pageParameters = UriParsingHelper.GetSegmentParameters(nextSegment);
-            if (pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation))
+            await page.Navigation.PopToRootAsync();
+
+            foreach (var destroyPage in pagesToDestroy)
             {
-                useModalNavigation = pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation);
-            }
-
-            if (nextSegment == RemovePageSegment)
-            {
-                await ProcessNavigationForRemovePageSegments(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
-                return;
-            }
-
-            if (currentPage is null)
-            {
-                await ProcessNavigationForRootPage(nextSegment, segments, parameters, useModalNavigation, animated);
-                return;
-            }
-
-            if (currentPage is ContentPage)
-            {
-                await ProcessNavigationForContentPage(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
-            }
-            else if (currentPage is NavigationPage nav)
-            {
-                await ProcessNavigationForNavigationPage(nav, nextSegment, segments, parameters, useModalNavigation, animated);
-            }
-            else if (currentPage is TabbedPage tabbed)
-            {
-                await ProcessNavigationForTabbedPage(tabbed, nextSegment, segments, parameters, useModalNavigation, animated);
-            }
-            else if (currentPage is FlyoutPage flyout)
-            {
-                await ProcessNavigationForFlyoutPage(flyout, nextSegment, segments, parameters, useModalNavigation, animated);
-            }
-        }
-
-        protected virtual Task ProcessNavigationForRemovePageSegments(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            if (!PageUtilities.HasDirectNavigationPageParent(currentPage))
-            {
-                throw new NavigationException(NavigationException.RelativeNavigationRequiresNavigationPage, currentPage);
-            }
-
-            return CanRemoveAndPush(segments)
-                ? RemoveAndPush(currentPage, nextSegment, segments, parameters, useModalNavigation, animated)
-                : RemoveAndGoBack(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
-        }
-
-        private static bool CanRemoveAndPush(Queue<string> segments)
-        {
-            return !segments.All(x => x == RemovePageSegment);
-        }
-
-        private Task RemoveAndGoBack(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            var pagesToRemove = new List<Page>();
-
-            var currentPageIndex = currentPage.Navigation.NavigationStack.Count;
-            if (currentPage.Navigation.NavigationStack.Count > 0)
-            {
-                currentPageIndex = currentPage.Navigation.NavigationStack.Count - 1;
-            }
-
-            while (segments.Count != 0)
-            {
-                currentPageIndex -= 1;
-                pagesToRemove.Add(currentPage.Navigation.NavigationStack[currentPageIndex]);
-                nextSegment = segments.Dequeue();
-            }
-
-            RemovePagesFromNavigationPage(currentPage, pagesToRemove);
-
-            return GoBackAsync(parameters);
-        }
-
-        private async Task RemoveAndPush(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            var pagesToRemove = new List<Page>
-            {
-                currentPage
-            };
-
-            var currentPageIndex = currentPage.Navigation.NavigationStack.Count;
-            if (currentPage.Navigation.NavigationStack.Count > 0)
-            {
-                currentPageIndex = currentPage.Navigation.NavigationStack.Count - 1;
-            }
-
-            while (segments.Peek() == RemovePageSegment)
-            {
-                currentPageIndex -= 1;
-                pagesToRemove.Add(currentPage.Navigation.NavigationStack[currentPageIndex]);
-                nextSegment = segments.Dequeue();
-            }
-
-            await ProcessNavigation(currentPage, segments, parameters, useModalNavigation, animated);
-
-            RemovePagesFromNavigationPage(currentPage, pagesToRemove);
-        }
-
-        private static void RemovePagesFromNavigationPage(Page currentPage, List<Page> pagesToRemove)
-        {
-            var navigationPage = (NavigationPage)currentPage.Parent;
-            foreach (var page in pagesToRemove)
-            {
-                navigationPage.Navigation.RemovePage(page);
-                PageUtilities.DestroyPage(page);
-            }
-        }
-
-        protected virtual Task ProcessNavigationForAbsoluteUri(Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            return ProcessNavigation(null, segments, parameters, useModalNavigation, animated);
-        }
-
-        protected virtual async Task ProcessNavigationForRootPage(string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            var nextPage = CreatePageFromSegment(nextSegment);
-
-            await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
-
-            var currentPage = GetPageFromWindow();
-            var modalStack = currentPage?.Navigation.ModalStack.ToList();
-            await DoNavigateAction(GetCurrentPage(), nextSegment, nextPage, parameters, async () =>
-            {
-                await DoPush(null, nextPage, useModalNavigation, animated);
-            });
-            if (currentPage != null)
-            {
-                PageUtilities.DestroyWithModalStack(currentPage, modalStack);
-            }
-        }
-
-        protected virtual async Task ProcessNavigationForContentPage(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            var nextPageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
-            bool useReverse = UseReverseNavigation(currentPage, nextPageType) && !(useModalNavigation.HasValue && useModalNavigation.Value);
-            if (!useReverse)
-            {
-                var nextPage = CreatePageFromSegment(nextSegment);
-
-                await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
-
-                await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
-                {
-                    await DoPush(currentPage, nextPage, useModalNavigation, animated);
-                });
-            }
-            else
-            {
-                await UseReverseNavigation(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
-            }
-        }
-
-        protected virtual async Task ProcessNavigationForNavigationPage(NavigationPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-        {
-            if (currentPage.Navigation.NavigationStack.Count == 0)
-            {
-                await UseReverseNavigation(currentPage, nextSegment, segments, parameters, false, animated);
-                return;
-            }
-
-            var clearNavigationStack = GetClearNavigationPageNavigationStack(currentPage);
-            var isEmptyOfNavigationStack = currentPage.Navigation.NavigationStack.Count == 0;
-
-            List<Page> destroyPages;
-            if (clearNavigationStack && !isEmptyOfNavigationStack)
-            {
-                destroyPages = currentPage.Navigation.NavigationStack.ToList();
-                destroyPages.Reverse();
-
-                await currentPage.Navigation.PopToRootAsync(false);
-            }
-            else
-            {
-                destroyPages = new List<Page>();
-            }
-
-            var topPage = currentPage.Navigation.NavigationStack.LastOrDefault();
-            var nextPageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
-            if (topPage?.GetType() == nextPageType)
-            {
-                if (clearNavigationStack)
-                    destroyPages.Remove(destroyPages.Last());
-
-                if (segments.Count > 0)
-                    await UseReverseNavigation(topPage, segments.Dequeue(), segments, parameters, false, animated);
-
-                await DoNavigateAction(topPage, nextSegment, topPage, parameters, onNavigationActionCompleted: (p) =>
-                {
-                    if (nextSegment.Contains(KnownNavigationParameters.SelectedTab))
-                    {
-                        var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                        SelectPageTab(topPage, segmentParams);
-                    }
-                });
-            }
-            else
-            {
-                await UseReverseNavigation(currentPage, nextSegment, segments, parameters, false, animated);
-
-                if (clearNavigationStack && !isEmptyOfNavigationStack)
-                {
-                    currentPage.Navigation.RemovePage(topPage);
-                }
-            }
-
-            foreach (var destroyPage in destroyPages)
-            {
+                PageUtilities.OnNavigatedFrom(destroyPage, parameters);
                 PageUtilities.DestroyPage(destroyPage);
             }
+
+            PageUtilities.OnNavigatedTo(root, parameters);
+
+            return new NavigationResult { Success = true };
+        }
+        catch (Exception ex)
+        {
+            return new NavigationResult { Exception = ex };
+        }
+    }
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The name of the target to navigate to.</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
+    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
+    protected virtual Task<INavigationResult> NavigateInternal(string name, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        if (name.StartsWith(RemovePageRelativePath))
+        {
+            name = name.Replace(RemovePageRelativePath, RemovePageInstruction);
         }
 
-        protected virtual async Task ProcessNavigationForTabbedPage(TabbedPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+        return NavigateInternal(UriParsingHelper.Parse(name), parameters, useModalNavigation, animated);
+    }
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="uri"/>.
+    /// </summary>
+    /// <param name="uri">The Uri to navigate to</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
+    /// <example>
+    /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
+    /// </example>
+    public virtual Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters)
+    {
+        return NavigateInternal(uri, parameters, null, true);
+    }
+
+    /// <summary>
+    /// Initiates navigation to the target specified by the <paramref name="uri"/>.
+    /// </summary>
+    /// <param name="uri">The Uri to navigate to</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
+    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
+    /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
+    /// <example>
+    /// Navigate(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
+    /// </example>
+    protected async virtual Task<INavigationResult> NavigateInternal(Uri uri, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        try
+        {
+            NavigationSource = PageNavigationSource.NavigationService;
+
+            var navigationSegments = UriParsingHelper.GetUriSegments(uri);
+
+            if (uri.IsAbsoluteUri)
+            {
+                await ProcessNavigationForAbsoluteUri(navigationSegments, parameters, useModalNavigation, animated);
+                return new NavigationResult { Success = true };
+            }
+            else
+            {
+                await ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, animated);
+                return new NavigationResult { Success = true };
+            }
+        }
+        catch (Exception ex)
+        {
+            return new NavigationResult { Exception = ex };
+        }
+        finally
+        {
+            NavigationSource = PageNavigationSource.Device;
+        }
+    }
+
+    /// <summary>
+    /// Processes the Navigation for the Queued navigation segments
+    /// </summary>
+    /// <param name="currentPage">The Current <see cref="Page"/> that we are navigating from.</param>
+    /// <param name="segments">The Navigation <see cref="Uri"/> segments.</param>
+    /// <param name="parameters">The <see cref="INavigationParameters"/>.</param>
+    /// <param name="useModalNavigation"><see cref="Nullable{Boolean}"/> flag if we should force Modal Navigation.</param>
+    /// <param name="animated">If <c>true</c>, the navigation will be animated.</param>
+    /// <returns></returns>
+    protected virtual async Task ProcessNavigation(Page currentPage, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        if (segments.Count == 0)
+        {
+            return;
+        }
+
+        var nextSegment = segments.Dequeue();
+
+        var pageParameters = UriParsingHelper.GetSegmentParameters(nextSegment);
+        if (pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation))
+        {
+            useModalNavigation = pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation);
+        }
+
+        if (nextSegment == RemovePageSegment)
+        {
+            await ProcessNavigationForRemovePageSegments(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+            return;
+        }
+
+        if (currentPage is null)
+        {
+            await ProcessNavigationForRootPage(nextSegment, segments, parameters, useModalNavigation, animated);
+            return;
+        }
+
+        if (currentPage is ContentPage)
+        {
+            await ProcessNavigationForContentPage(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+        }
+        else if (currentPage is NavigationPage nav)
+        {
+            await ProcessNavigationForNavigationPage(nav, nextSegment, segments, parameters, useModalNavigation, animated);
+        }
+        else if (currentPage is TabbedPage tabbed)
+        {
+            await ProcessNavigationForTabbedPage(tabbed, nextSegment, segments, parameters, useModalNavigation, animated);
+        }
+        else if (currentPage is FlyoutPage flyout)
+        {
+            await ProcessNavigationForFlyoutPage(flyout, nextSegment, segments, parameters, useModalNavigation, animated);
+        }
+    }
+
+    protected virtual Task ProcessNavigationForRemovePageSegments(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        if (!PageUtilities.HasDirectNavigationPageParent(currentPage))
+        {
+            throw new NavigationException(NavigationException.RelativeNavigationRequiresNavigationPage, currentPage);
+        }
+
+        return CanRemoveAndPush(segments)
+            ? RemoveAndPush(currentPage, nextSegment, segments, parameters, useModalNavigation, animated)
+            : RemoveAndGoBack(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+    }
+
+    private static bool CanRemoveAndPush(Queue<string> segments)
+    {
+        return !segments.All(x => x == RemovePageSegment);
+    }
+
+    private Task RemoveAndGoBack(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        var pagesToRemove = new List<Page>();
+
+        var currentPageIndex = currentPage.Navigation.NavigationStack.Count;
+        if (currentPage.Navigation.NavigationStack.Count > 0)
+        {
+            currentPageIndex = currentPage.Navigation.NavigationStack.Count - 1;
+        }
+
+        while (segments.Count != 0)
+        {
+            currentPageIndex -= 1;
+            pagesToRemove.Add(currentPage.Navigation.NavigationStack[currentPageIndex]);
+            nextSegment = segments.Dequeue();
+        }
+
+        RemovePagesFromNavigationPage(currentPage, pagesToRemove);
+
+        return GoBackAsync(parameters);
+    }
+
+    private async Task RemoveAndPush(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        var pagesToRemove = new List<Page>
+        {
+            currentPage
+        };
+
+        var currentPageIndex = currentPage.Navigation.NavigationStack.Count;
+        if (currentPage.Navigation.NavigationStack.Count > 0)
+        {
+            currentPageIndex = currentPage.Navigation.NavigationStack.Count - 1;
+        }
+
+        while (segments.Peek() == RemovePageSegment)
+        {
+            currentPageIndex -= 1;
+            pagesToRemove.Add(currentPage.Navigation.NavigationStack[currentPageIndex]);
+            nextSegment = segments.Dequeue();
+        }
+
+        await ProcessNavigation(currentPage, segments, parameters, useModalNavigation, animated);
+
+        RemovePagesFromNavigationPage(currentPage, pagesToRemove);
+    }
+
+    private static void RemovePagesFromNavigationPage(Page currentPage, List<Page> pagesToRemove)
+    {
+        var navigationPage = (NavigationPage)currentPage.Parent;
+        foreach (var page in pagesToRemove)
+        {
+            navigationPage.Navigation.RemovePage(page);
+            PageUtilities.DestroyPage(page);
+        }
+    }
+
+    protected virtual Task ProcessNavigationForAbsoluteUri(Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        return ProcessNavigation(null, segments, parameters, useModalNavigation, animated);
+    }
+
+    protected virtual async Task ProcessNavigationForRootPage(string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        var nextPage = CreatePageFromSegment(nextSegment);
+
+        await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
+
+        var currentPage = GetPageFromWindow();
+        var modalStack = currentPage?.Navigation.ModalStack.ToList();
+        await DoNavigateAction(GetCurrentPage(), nextSegment, nextPage, parameters, async () =>
+        {
+            await DoPush(null, nextPage, useModalNavigation, animated);
+        });
+        if (currentPage != null)
+        {
+            PageUtilities.DestroyWithModalStack(currentPage, modalStack);
+        }
+    }
+
+    protected virtual async Task ProcessNavigationForContentPage(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        var nextPageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
+        bool useReverse = UseReverseNavigation(currentPage, nextPageType) && !(useModalNavigation.HasValue && useModalNavigation.Value);
+        if (!useReverse)
         {
             var nextPage = CreatePageFromSegment(nextSegment);
+
             await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
+
             await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
             {
                 await DoPush(currentPage, nextPage, useModalNavigation, animated);
             });
         }
-
-        protected virtual async Task ProcessNavigationForFlyoutPage(FlyoutPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+        else
         {
-            bool isPresented = GetFlyoutPageIsPresented(currentPage);
+            await UseReverseNavigation(currentPage, nextSegment, segments, parameters, useModalNavigation, animated);
+        }
+    }
 
-            var detail = currentPage.Detail;
-            if (detail is null)
+    protected virtual async Task ProcessNavigationForNavigationPage(NavigationPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        if (currentPage.Navigation.NavigationStack.Count == 0)
+        {
+            await UseReverseNavigation(currentPage, nextSegment, segments, parameters, false, animated);
+            return;
+        }
+
+        var clearNavigationStack = GetClearNavigationPageNavigationStack(currentPage);
+        var isEmptyOfNavigationStack = currentPage.Navigation.NavigationStack.Count == 0;
+
+        List<Page> destroyPages;
+        if (clearNavigationStack && !isEmptyOfNavigationStack)
+        {
+            destroyPages = currentPage.Navigation.NavigationStack.ToList();
+            destroyPages.Reverse();
+
+            await currentPage.Navigation.PopToRootAsync(false);
+        }
+        else
+        {
+            destroyPages = new List<Page>();
+        }
+
+        var topPage = currentPage.Navigation.NavigationStack.LastOrDefault();
+        var nextPageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
+        if (topPage?.GetType() == nextPageType)
+        {
+            if (clearNavigationStack)
+                destroyPages.Remove(destroyPages.Last());
+
+            if (segments.Count > 0)
+                await UseReverseNavigation(topPage, segments.Dequeue(), segments, parameters, false, animated);
+
+            await DoNavigateAction(topPage, nextSegment, topPage, parameters, onNavigationActionCompleted: (p) =>
             {
-                var newDetail = CreatePageFromSegment(nextSegment);
-                await ProcessNavigation(newDetail, segments, parameters, useModalNavigation, animated);
-                await DoNavigateAction(null, nextSegment, newDetail, parameters, onNavigationActionCompleted: (p) =>
+                if (nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                 {
-                    currentPage.IsPresented = isPresented;
-                    currentPage.Detail = newDetail;
-                });
-                return;
-            }
-
-            if (useModalNavigation.HasValue && useModalNavigation.Value)
-            {
-                var nextPage = CreatePageFromSegment(nextSegment);
-                await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
-                await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
-                {
-                    currentPage.IsPresented = isPresented;
-                    await DoPush(currentPage, nextPage, true, animated);
-                });
-                return;
-            }
-
-            var nextSegmentType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
-
-            //we must recreate the NavigationPage everytime or the transitions on iOS will not work properly, unless we meet the two scenarios below
-            bool detailIsNavPage = false;
-            bool reuseNavPage = false;
-            if (detail is NavigationPage navPage)
-            {
-                detailIsNavPage = true;
-
-                //we only care if we the next segment is also a NavigationPage.
-                if (PageUtilities.IsSameOrSubclassOf<NavigationPage>(nextSegmentType))
-                {
-                    //first we check to see if we are being forced to reuse the NavPage by checking the interface
-                    reuseNavPage = !GetClearNavigationPageNavigationStack(navPage);
-
-                    if (!reuseNavPage)
-                    {
-                        //if we weren't forced to reuse the NavPage, then let's check the NavPage.CurrentPage against the next segment type as we don't want to recreate the entire nav stack
-                        //just in case the user is trying to navigate to the same page which may be nested in a NavPage
-                        var nextPageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(segments.Peek()));
-                        var currentPageType = navPage.CurrentPage.GetType();
-                        if (nextPageType == currentPageType)
-                        {
-                            reuseNavPage = true;
-                        }
-                    }
+                    var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
+                    SelectPageTab(topPage, segmentParams);
                 }
-            }
+            });
+        }
+        else
+        {
+            await UseReverseNavigation(currentPage, nextSegment, segments, parameters, false, animated);
 
-            if ((detailIsNavPage && reuseNavPage) || (!detailIsNavPage && detail.GetType() == nextSegmentType))
+            if (clearNavigationStack && !isEmptyOfNavigationStack)
             {
-                await ProcessNavigation(detail, segments, parameters, useModalNavigation, animated);
-                await DoNavigateAction(null, nextSegment, detail, parameters, onNavigationActionCompleted: (p) =>
+                currentPage.Navigation.RemovePage(topPage);
+            }
+        }
+
+        foreach (var destroyPage in destroyPages)
+        {
+            PageUtilities.DestroyPage(destroyPage);
+        }
+    }
+
+    protected virtual async Task ProcessNavigationForTabbedPage(TabbedPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        var nextPage = CreatePageFromSegment(nextSegment);
+        await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
+        await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
+        {
+            await DoPush(currentPage, nextPage, useModalNavigation, animated);
+        });
+    }
+
+    protected virtual async Task ProcessNavigationForFlyoutPage(FlyoutPage currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        bool isPresented = GetFlyoutPageIsPresented(currentPage);
+
+        var detail = currentPage.Detail;
+        if (detail is null)
+        {
+            var newDetail = CreatePageFromSegment(nextSegment);
+            await ProcessNavigation(newDetail, segments, parameters, useModalNavigation, animated);
+            await DoNavigateAction(null, nextSegment, newDetail, parameters, onNavigationActionCompleted: (p) =>
+            {
+                currentPage.IsPresented = isPresented;
+                currentPage.Detail = newDetail;
+            });
+            return;
+        }
+
+        if (useModalNavigation.HasValue && useModalNavigation.Value)
+        {
+            var nextPage = CreatePageFromSegment(nextSegment);
+            await ProcessNavigation(nextPage, segments, parameters, useModalNavigation, animated);
+            await DoNavigateAction(currentPage, nextSegment, nextPage, parameters, async () =>
+            {
+                currentPage.IsPresented = isPresented;
+                await DoPush(currentPage, nextPage, true, animated);
+            });
+            return;
+        }
+
+        var nextSegmentType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(nextSegment));
+
+        //we must recreate the NavigationPage everytime or the transitions on iOS will not work properly, unless we meet the two scenarios below
+        bool detailIsNavPage = false;
+        bool reuseNavPage = false;
+        if (detail is NavigationPage navPage)
+        {
+            detailIsNavPage = true;
+
+            //we only care if we the next segment is also a NavigationPage.
+            if (PageUtilities.IsSameOrSubclassOf<NavigationPage>(nextSegmentType))
+            {
+                //first we check to see if we are being forced to reuse the NavPage by checking the interface
+                reuseNavPage = !GetClearNavigationPageNavigationStack(navPage);
+
+                if (!reuseNavPage)
                 {
-                    if (detail is TabbedPage && nextSegment.Contains(KnownNavigationParameters.SelectedTab))
+                    //if we weren't forced to reuse the NavPage, then let's check the NavPage.CurrentPage against the next segment type as we don't want to recreate the entire nav stack
+                    //just in case the user is trying to navigate to the same page which may be nested in a NavPage
+                    var nextPageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(segments.Peek()));
+                    var currentPageType = navPage.CurrentPage.GetType();
+                    if (nextPageType == currentPageType)
                     {
-                        var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
-                        SelectPageTab(detail, segmentParams);
-                    }
-
-                    currentPage.IsPresented = isPresented;
-                });
-                return;
-            }
-            else
-            {
-                var newDetail = CreatePageFromSegment(nextSegment);
-                await ProcessNavigation(newDetail, segments, parameters, newDetail is NavigationPage ? false : true, animated);
-                await DoNavigateAction(detail, nextSegment, newDetail, parameters, onNavigationActionCompleted: (p) =>
-                {
-                    if (detailIsNavPage)
-                        OnNavigatedFrom(((NavigationPage)detail).CurrentPage, p);
-
-                    currentPage.IsPresented = isPresented;
-                    currentPage.Detail = newDetail;
-                    PageUtilities.DestroyPage(detail);
-                });
-                return;
-            }
-        }
-
-        protected static bool GetFlyoutPageIsPresented(FlyoutPage page)
-        {
-            if (page is IFlyoutPageOptions flyoutPageOptions)
-                return flyoutPageOptions.IsPresentedAfterNavigation;
-
-            else if (page.BindingContext is IFlyoutPageOptions flyoutPageBindingContext)
-                return flyoutPageBindingContext.IsPresentedAfterNavigation;
-
-            return false;
-        }
-
-        protected static bool GetClearNavigationPageNavigationStack(NavigationPage page)
-        {
-            if (page is INavigationPageOptions iNavigationPage)
-                return iNavigationPage.ClearNavigationStackOnNavigation;
-
-            else if (page.BindingContext is INavigationPageOptions iNavigationPageBindingContext)
-                return iNavigationPageBindingContext.ClearNavigationStackOnNavigation;
-
-            return true;
-        }
-
-        protected static async Task DoNavigateAction(Page fromPage, string toSegment, Page toPage, INavigationParameters parameters, Func<Task> navigationAction = null, Action<INavigationParameters> onNavigationActionCompleted = null)
-        {
-            var segmentParameters = UriParsingHelper.GetSegmentParameters(toSegment, parameters);
-            segmentParameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.New);
-
-            var canNavigate = await PageUtilities.CanNavigateAsync(fromPage, segmentParameters);
-            if (!canNavigate)
-            {
-                throw new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, toPage);
-            }
-
-            await OnInitializedAsync(toPage, segmentParameters);
-
-            if (navigationAction != null)
-            {
-                await navigationAction();
-            }
-
-            OnNavigatedFrom(fromPage, segmentParameters);
-
-            onNavigationActionCompleted?.Invoke(segmentParameters);
-
-            OnNavigatedTo(toPage, segmentParameters);
-        }
-
-        static async Task OnInitializedAsync(Page toPage, INavigationParameters parameters)
-        {
-            await PageUtilities.OnInitializedAsync(toPage, parameters);
-
-            if (toPage is TabbedPage tabbedPage)
-            {
-                foreach (var child in tabbedPage.Children)
-                {
-                    if (child is NavigationPage navigationPage)
-                    {
-                        await PageUtilities.OnInitializedAsync(navigationPage.CurrentPage, parameters);
-                    }
-                    else
-                    {
-                        await PageUtilities.OnInitializedAsync(child, parameters);
+                        reuseNavPage = true;
                     }
                 }
             }
         }
 
-        private static void OnNavigatedTo(Page toPage, INavigationParameters parameters)
+        if ((detailIsNavPage && reuseNavPage) || (!detailIsNavPage && detail.GetType() == nextSegmentType))
         {
-            PageUtilities.OnNavigatedTo(toPage, parameters);
-
-            if (toPage is TabbedPage tabbedPage)
+            await ProcessNavigation(detail, segments, parameters, useModalNavigation, animated);
+            await DoNavigateAction(null, nextSegment, detail, parameters, onNavigationActionCompleted: (p) =>
             {
-                if (tabbedPage.CurrentPage is NavigationPage navigationPage)
+                if (detail is TabbedPage && nextSegment.Contains(KnownNavigationParameters.SelectedTab))
                 {
-                    PageUtilities.OnNavigatedTo(navigationPage.CurrentPage, parameters);
+                    var segmentParams = UriParsingHelper.GetSegmentParameters(nextSegment);
+                    SelectPageTab(detail, segmentParams);
                 }
-                else if (tabbedPage.BindingContext != tabbedPage.CurrentPage.BindingContext)
+
+                currentPage.IsPresented = isPresented;
+            });
+            return;
+        }
+        else
+        {
+            var newDetail = CreatePageFromSegment(nextSegment);
+            await ProcessNavigation(newDetail, segments, parameters, newDetail is NavigationPage ? false : true, animated);
+            await DoNavigateAction(detail, nextSegment, newDetail, parameters, onNavigationActionCompleted: (p) =>
+            {
+                if (detailIsNavPage)
+                    OnNavigatedFrom(((NavigationPage)detail).CurrentPage, p);
+
+                currentPage.IsPresented = isPresented;
+                currentPage.Detail = newDetail;
+                PageUtilities.DestroyPage(detail);
+            });
+            return;
+        }
+    }
+
+    protected static bool GetFlyoutPageIsPresented(FlyoutPage page)
+    {
+        if (page is IFlyoutPageOptions flyoutPageOptions)
+            return flyoutPageOptions.IsPresentedAfterNavigation;
+
+        else if (page.BindingContext is IFlyoutPageOptions flyoutPageBindingContext)
+            return flyoutPageBindingContext.IsPresentedAfterNavigation;
+
+        return false;
+    }
+
+    protected static bool GetClearNavigationPageNavigationStack(NavigationPage page)
+    {
+        if (page is INavigationPageOptions iNavigationPage)
+            return iNavigationPage.ClearNavigationStackOnNavigation;
+
+        else if (page.BindingContext is INavigationPageOptions iNavigationPageBindingContext)
+            return iNavigationPageBindingContext.ClearNavigationStackOnNavigation;
+
+        return true;
+    }
+
+    protected static async Task DoNavigateAction(Page fromPage, string toSegment, Page toPage, INavigationParameters parameters, Func<Task> navigationAction = null, Action<INavigationParameters> onNavigationActionCompleted = null)
+    {
+        var segmentParameters = UriParsingHelper.GetSegmentParameters(toSegment, parameters);
+        segmentParameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.New);
+
+        var canNavigate = await PageUtilities.CanNavigateAsync(fromPage, segmentParameters);
+        if (!canNavigate)
+        {
+            throw new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, toPage);
+        }
+
+        await OnInitializedAsync(toPage, segmentParameters);
+
+        if (navigationAction != null)
+        {
+            await navigationAction();
+        }
+
+        OnNavigatedFrom(fromPage, segmentParameters);
+
+        onNavigationActionCompleted?.Invoke(segmentParameters);
+
+        OnNavigatedTo(toPage, segmentParameters);
+    }
+
+    static async Task OnInitializedAsync(Page toPage, INavigationParameters parameters)
+    {
+        await PageUtilities.OnInitializedAsync(toPage, parameters);
+
+        if (toPage is TabbedPage tabbedPage)
+        {
+            foreach (var child in tabbedPage.Children)
+            {
+                if (child is NavigationPage navigationPage)
                 {
-                    PageUtilities.OnNavigatedTo(tabbedPage.CurrentPage, parameters);
+                    await PageUtilities.OnInitializedAsync(navigationPage.CurrentPage, parameters);
+                }
+                else
+                {
+                    await PageUtilities.OnInitializedAsync(child, parameters);
                 }
             }
         }
+    }
 
-        private static void OnNavigatedFrom(Page fromPage, INavigationParameters parameters)
+    private static void OnNavigatedTo(Page toPage, INavigationParameters parameters)
+    {
+        PageUtilities.OnNavigatedTo(toPage, parameters);
+
+        if (toPage is TabbedPage tabbedPage)
         {
-            PageUtilities.OnNavigatedFrom(fromPage, parameters);
-
-            if (fromPage is TabbedPage tabbedPage)
+            if (tabbedPage.CurrentPage is NavigationPage navigationPage)
             {
-                if (tabbedPage.CurrentPage is NavigationPage navigationPage)
-                {
-                    PageUtilities.OnNavigatedFrom(navigationPage.CurrentPage, parameters);
-                }
-                else if (tabbedPage.BindingContext != tabbedPage.CurrentPage.BindingContext)
-                {
-                    PageUtilities.OnNavigatedFrom(tabbedPage.CurrentPage, parameters);
-                }
+                PageUtilities.OnNavigatedTo(navigationPage.CurrentPage, parameters);
+            }
+            else if (tabbedPage.BindingContext != tabbedPage.CurrentPage.BindingContext)
+            {
+                PageUtilities.OnNavigatedTo(tabbedPage.CurrentPage, parameters);
             }
         }
+    }
 
-        protected virtual Page CreatePage(string segmentName)
+    private static void OnNavigatedFrom(Page fromPage, INavigationParameters parameters)
+    {
+        PageUtilities.OnNavigatedFrom(fromPage, parameters);
+
+        if (fromPage is TabbedPage tabbedPage)
         {
-            try
+            if (tabbedPage.CurrentPage is NavigationPage navigationPage)
             {
-                _container.CreateScope();
-                var page = (Page)NavigationRegistry.CreateView(_container, segmentName);
-
-                if (page is null)
-                    throw new NullReferenceException($"The resolved type for {segmentName} was null. You may be attempting to navigate to a Non-Page type");
-
-                return page;
+                PageUtilities.OnNavigatedFrom(navigationPage.CurrentPage, parameters);
             }
-            catch (Exception ex)
+            else if (tabbedPage.BindingContext != tabbedPage.CurrentPage.BindingContext)
             {
-                if (ex is NavigationException)
-                    throw;
-
-                else if(ex is KeyNotFoundException)
-                    throw new NavigationException(NavigationException.NoPageIsRegistered, _page, ex);
-
-                throw new NavigationException(NavigationException.ErrorCreatingPage, _page, ex);
+                PageUtilities.OnNavigatedFrom(tabbedPage.CurrentPage, parameters);
             }
         }
+    }
 
-        protected virtual Page CreatePageFromSegment(string segment)
+    protected virtual Page CreatePage(string segmentName)
+    {
+        try
         {
-            string segmentName = UriParsingHelper.GetSegmentName(segment);
-            var page = CreatePage(segmentName);
+            _container.CreateScope();
+            var page = (Page)NavigationRegistry.CreateView(_container, segmentName);
+
             if (page is null)
-            {
-                var innerException = new NullReferenceException(string.Format("{0} could not be created. Please make sure you have registered {0} for navigation.", segmentName));
-                throw new NavigationException(NavigationException.NoPageIsRegistered, _page, innerException);
-            }
-
-            ConfigurePages(page, segment);
+                throw new NullReferenceException($"The resolved type for {segmentName} was null. You may be attempting to navigate to a Non-Page type");
 
             return page;
         }
-
-        void ConfigurePages(Page page, string segment)
+        catch (Exception ex)
         {
-            if (page is TabbedPage)
-            {
-                ConfigureTabbedPage((TabbedPage)page, segment);
-            }
+            if (ex is NavigationException)
+                throw;
+
+            else if(ex is KeyNotFoundException)
+                throw new NavigationException(NavigationException.NoPageIsRegistered, _page, ex);
+
+            throw new NavigationException(NavigationException.ErrorCreatingPage, _page, ex);
+        }
+    }
+
+    protected virtual Page CreatePageFromSegment(string segment)
+    {
+        string segmentName = UriParsingHelper.GetSegmentName(segment);
+        var page = CreatePage(segmentName);
+        if (page is null)
+        {
+            var innerException = new NullReferenceException(string.Format("{0} could not be created. Please make sure you have registered {0} for navigation.", segmentName));
+            throw new NavigationException(NavigationException.NoPageIsRegistered, _page, innerException);
         }
 
-        void ConfigureTabbedPage(TabbedPage tabbedPage, string segment)
+        ConfigurePages(page, segment);
+
+        return page;
+    }
+
+    void ConfigurePages(Page page, string segment)
+    {
+        if (page is TabbedPage)
         {
-            var parameters = UriParsingHelper.GetSegmentParameters(segment);
+            ConfigureTabbedPage((TabbedPage)page, segment);
+        }
+    }
 
-            var tabsToCreate = parameters.GetValues<string>(KnownNavigationParameters.CreateTab);
-            if (tabsToCreate.Count() > 0)
+    void ConfigureTabbedPage(TabbedPage tabbedPage, string segment)
+    {
+        var parameters = UriParsingHelper.GetSegmentParameters(segment);
+
+        var tabsToCreate = parameters.GetValues<string>(KnownNavigationParameters.CreateTab);
+        if (tabsToCreate.Count() > 0)
+        {
+            foreach (var tabToCreate in tabsToCreate)
             {
-                foreach (var tabToCreate in tabsToCreate)
+                //created tab can be a single view or a view nested in a NavigationPage with the syntax "NavigationPage|ViewToCreate"
+                var tabSegments = tabToCreate.Split('|');
+                if (tabSegments.Length > 1)
                 {
-                    //created tab can be a single view or a view nested in a NavigationPage with the syntax "NavigationPage|ViewToCreate"
-                    var tabSegments = tabToCreate.Split('|');
-                    if (tabSegments.Length > 1)
+                    var navigationPage = CreatePageFromSegment(tabSegments[0]) as NavigationPage;
+                    if (navigationPage != null)
                     {
-                        var navigationPage = CreatePageFromSegment(tabSegments[0]) as NavigationPage;
-                        if (navigationPage != null)
-                        {
-                            var navigationPageChild = CreatePageFromSegment(tabSegments[1]);
+                        var navigationPageChild = CreatePageFromSegment(tabSegments[1]);
 
-                            navigationPage.PushAsync(navigationPageChild);
+                        navigationPage.PushAsync(navigationPageChild);
 
-                            //when creating a NavigationPage w/ DI, a blank Page object is injected into the ctor. Let's remove it
-                            if (navigationPage.Navigation.NavigationStack.Count > 1)
-                                navigationPage.Navigation.RemovePage(navigationPage.Navigation.NavigationStack[0]);
+                        //when creating a NavigationPage w/ DI, a blank Page object is injected into the ctor. Let's remove it
+                        if (navigationPage.Navigation.NavigationStack.Count > 1)
+                            navigationPage.Navigation.RemovePage(navigationPage.Navigation.NavigationStack[0]);
 
-                            //set the title because Xamarin doesn't do this for us.
-                            navigationPage.Title = navigationPageChild.Title;
-                            navigationPage.IconImageSource = navigationPageChild.IconImageSource;
+                        //set the title because Xamarin doesn't do this for us.
+                        navigationPage.Title = navigationPageChild.Title;
+                        navigationPage.IconImageSource = navigationPageChild.IconImageSource;
 
-                            tabbedPage.Children.Add(navigationPage);
-                        }
-                    }
-                    else
-                    {
-                        var tab = CreatePageFromSegment(tabToCreate);
-                        tabbedPage.Children.Add(tab);
+                        tabbedPage.Children.Add(navigationPage);
                     }
                 }
+                else
+                {
+                    var tab = CreatePageFromSegment(tabToCreate);
+                    tabbedPage.Children.Add(tab);
+                }
             }
+        }
 
+        TabbedPageSelectTab(tabbedPage, parameters);
+    }
+
+    private static void SelectPageTab(Page page, INavigationParameters parameters)
+    {
+        if (page is TabbedPage tabbedPage)
+        {
             TabbedPageSelectTab(tabbedPage, parameters);
         }
+    }
 
-        private static void SelectPageTab(Page page, INavigationParameters parameters)
+    private static void TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters)
+    {
+        var selectedTab = parameters?.GetValue<string>(KnownNavigationParameters.SelectedTab);
+        if (!string.IsNullOrWhiteSpace(selectedTab))
         {
-            if (page is TabbedPage tabbedPage)
-            {
-                TabbedPageSelectTab(tabbedPage, parameters);
-            }
-        }
+            var selectedTabType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTab));
 
-        private static void TabbedPageSelectTab(TabbedPage tabbedPage, INavigationParameters parameters)
-        {
-            var selectedTab = parameters?.GetValue<string>(KnownNavigationParameters.SelectedTab);
-            if (!string.IsNullOrWhiteSpace(selectedTab))
+            var childFound = false;
+            foreach (var child in tabbedPage.Children)
             {
-                var selectedTabType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(selectedTab));
-
-                var childFound = false;
-                foreach (var child in tabbedPage.Children)
+                if (!childFound && child.GetType() == selectedTabType)
                 {
-                    if (!childFound && child.GetType() == selectedTabType)
+                    tabbedPage.CurrentPage = child;
+                    childFound = true;
+                }
+
+                if (child is NavigationPage)
+                {
+                    if (!childFound && ((NavigationPage)child).CurrentPage.GetType() == selectedTabType)
                     {
                         tabbedPage.CurrentPage = child;
                         childFound = true;
                     }
-
-                    if (child is NavigationPage)
-                    {
-                        if (!childFound && ((NavigationPage)child).CurrentPage.GetType() == selectedTabType)
-                        {
-                            tabbedPage.CurrentPage = child;
-                            childFound = true;
-                        }
-                    }
                 }
             }
         }
+    }
 
-        protected virtual async Task UseReverseNavigation(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    protected virtual async Task UseReverseNavigation(Page currentPage, string nextSegment, Queue<string> segments, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    {
+        var navigationStack = new Stack<string>();
+
+        if (!string.IsNullOrWhiteSpace(nextSegment))
+            navigationStack.Push(nextSegment);
+
+        var illegalSegments = new Queue<string>();
+
+        bool illegalPageFound = false;
+        foreach (var item in segments)
         {
-            var navigationStack = new Stack<string>();
-
-            if (!string.IsNullOrWhiteSpace(nextSegment))
-                navigationStack.Push(nextSegment);
-
-            var illegalSegments = new Queue<string>();
-
-            bool illegalPageFound = false;
-            foreach (var item in segments)
+            //if we run into an illegal page, we need to create new navigation segments to properly handle the deep link
+            if (illegalPageFound)
             {
-                //if we run into an illegal page, we need to create new navigation segments to properly handle the deep link
-                if (illegalPageFound)
+                illegalSegments.Enqueue(item);
+                continue;
+            }
+
+            //if any page decide to go modal, we need to consider it and all pages after it an illegal page
+            var pageParameters = UriParsingHelper.GetSegmentParameters(item);
+            if (pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation))
+            {
+                if (pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation))
                 {
                     illegalSegments.Enqueue(item);
-                    continue;
-                }
-
-                //if any page decide to go modal, we need to consider it and all pages after it an illegal page
-                var pageParameters = UriParsingHelper.GetSegmentParameters(item);
-                if (pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation))
-                {
-                    if (pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation))
-                    {
-                        illegalSegments.Enqueue(item);
-                        illegalPageFound = true;
-                    }
-                    else
-                    {
-                        navigationStack.Push(item);
-                    }
+                    illegalPageFound = true;
                 }
                 else
                 {
-                    var pageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(item));
-                    if (PageUtilities.IsSameOrSubclassOf<FlyoutPage>(pageType))
-                    {
-                        illegalSegments.Enqueue(item);
-                        illegalPageFound = true;
-                    }
-                    else
-                    {
-                        navigationStack.Push(item);
-                    }
+                    navigationStack.Push(item);
                 }
             }
-
-            var pageOffset = currentPage.Navigation.NavigationStack.Count;
-            if (currentPage.Navigation.NavigationStack.Count > 2)
-                pageOffset = currentPage.Navigation.NavigationStack.Count - 1;
-
-            var onNavigatedFromTarget = currentPage;
-            if (currentPage is NavigationPage navPage && navPage.CurrentPage != null)
-                onNavigatedFromTarget = navPage.CurrentPage;
-
-            bool insertBefore = false;
-            while (navigationStack.Count > 0)
+            else
             {
-                var segment = navigationStack.Pop();
-                var nextPage = CreatePageFromSegment(segment);
-                await DoNavigateAction(onNavigatedFromTarget, segment, nextPage, parameters, async () =>
+                var pageType = NavigationRegistry.GetPageType(UriParsingHelper.GetSegmentName(item));
+                if (PageUtilities.IsSameOrSubclassOf<FlyoutPage>(pageType))
                 {
-                    await DoPush(currentPage, nextPage, useModalNavigation, animated, insertBefore, pageOffset);
-                });
-                insertBefore = true;
-            }
-
-            //if an illegal page is found, we force a Modal navigation
-            if (illegalSegments.Count > 0)
-                await ProcessNavigation(currentPage.Navigation.NavigationStack.Last(), illegalSegments, parameters, true, animated);
-        }
-
-        protected virtual Task DoPush(Page currentPage, Page page, bool? useModalNavigation, bool animated, bool insertBeforeLast = false, int navigationOffset = 0)
-        {
-            if (page is null)
-                throw new ArgumentNullException(nameof(page));
-
-            // Prevent Page from using Parent's ViewModel
-            if (page.BindingContext is null)
-                page.BindingContext = new object();
-
-            if (currentPage is null)
-            {
-                var pageWindow = _page?.GetParentWindow();
-                if (Window is null && pageWindow is not null)
-                    Window = pageWindow;
-                else if (_application.Windows.OfType<PrismWindow>().Any(x => x.Name == PrismWindow.DefaultWindowName))
-                    Window = _application.Windows.OfType<PrismWindow>().First(x => x.Name == PrismWindow.DefaultWindowName);
-
-                if (Window is null)
-                {
-                    Window = new PrismWindow
-                    {
-                        Page = page
-                    };
-                    ((List<Window>)_application.Windows).Add(Window as PrismWindow);
+                    illegalSegments.Enqueue(item);
+                    illegalPageFound = true;
                 }
                 else
                 {
-                    // BUG: https://github.com/dotnet/maui/issues/7275
-                    //Window.Page = page;
-
-                    // HACK: This is the only way CURRENTLY to ensure that the UI resets for Absolute Navigation
-                    var newWindow = new PrismWindow
-                    {
-                        Page = page
-                    };
-                    _application.OpenWindow(newWindow);
-                    _application.CloseWindow(Window);
-                    Window = null;
+                    navigationStack.Push(item);
                 }
+            }
+        }
 
-                return Task.FromResult<object>(null);
+        var pageOffset = currentPage.Navigation.NavigationStack.Count;
+        if (currentPage.Navigation.NavigationStack.Count > 2)
+            pageOffset = currentPage.Navigation.NavigationStack.Count - 1;
+
+        var onNavigatedFromTarget = currentPage;
+        if (currentPage is NavigationPage navPage && navPage.CurrentPage != null)
+            onNavigatedFromTarget = navPage.CurrentPage;
+
+        bool insertBefore = false;
+        while (navigationStack.Count > 0)
+        {
+            var segment = navigationStack.Pop();
+            var nextPage = CreatePageFromSegment(segment);
+            await DoNavigateAction(onNavigatedFromTarget, segment, nextPage, parameters, async () =>
+            {
+                await DoPush(currentPage, nextPage, useModalNavigation, animated, insertBefore, pageOffset);
+            });
+            insertBefore = true;
+        }
+
+        //if an illegal page is found, we force a Modal navigation
+        if (illegalSegments.Count > 0)
+            await ProcessNavigation(currentPage.Navigation.NavigationStack.Last(), illegalSegments, parameters, true, animated);
+    }
+
+    protected virtual Task DoPush(Page currentPage, Page page, bool? useModalNavigation, bool animated, bool insertBeforeLast = false, int navigationOffset = 0)
+    {
+        if (page is null)
+            throw new ArgumentNullException(nameof(page));
+
+        // Prevent Page from using Parent's ViewModel
+        if (page.BindingContext is null)
+            page.BindingContext = new object();
+
+        if (currentPage is null)
+        {
+            var pageWindow = _page?.GetParentWindow();
+            if (Window is null && pageWindow is not null)
+                Window = pageWindow;
+            else if (_application.Windows.OfType<PrismWindow>().Any(x => x.Name == PrismWindow.DefaultWindowName))
+                Window = _application.Windows.OfType<PrismWindow>().First(x => x.Name == PrismWindow.DefaultWindowName);
+
+            if (Window is null)
+            {
+                Window = new PrismWindow
+                {
+                    Page = page
+                };
+                ((List<Window>)_application.Windows).Add(Window as PrismWindow);
             }
             else
             {
-                bool useModalForPush = UseModalNavigation(currentPage, useModalNavigation);
+                // BUG: https://github.com/dotnet/maui/issues/7275
+                //Window.Page = page;
 
-                if (useModalForPush)
+                // HACK: This is the only way CURRENTLY to ensure that the UI resets for Absolute Navigation
+                var newWindow = new PrismWindow
                 {
-                    return currentPage.Navigation.PushModalAsync(page, animated);
+                    Page = page
+                };
+                _application.OpenWindow(newWindow);
+                _application.CloseWindow(Window);
+                Window = null;
+            }
+
+            return Task.FromResult<object>(null);
+        }
+        else
+        {
+            bool useModalForPush = UseModalNavigation(currentPage, useModalNavigation);
+
+            if (useModalForPush)
+            {
+                return currentPage.Navigation.PushModalAsync(page, animated);
+            }
+            else
+            {
+                if (insertBeforeLast)
+                {
+                    return InsertPageBefore(currentPage, page, navigationOffset);
                 }
                 else
                 {
-                    if (insertBeforeLast)
-                    {
-                        return InsertPageBefore(currentPage, page, navigationOffset);
-                    }
-                    else
-                    {
-                        return currentPage.Navigation.PushAsync(page, animated);
-                    }
+                    return currentPage.Navigation.PushAsync(page, animated);
                 }
             }
         }
+    }
 
-        protected virtual Task InsertPageBefore(Page currentPage, Page page, int pageOffset)
-        {
-            var firstPage = currentPage.Navigation.NavigationStack.Skip(pageOffset).FirstOrDefault();
-            currentPage.Navigation.InsertPageBefore(page, firstPage);
-            return Task.FromResult(true);
-        }
+    protected virtual Task InsertPageBefore(Page currentPage, Page page, int pageOffset)
+    {
+        var firstPage = currentPage.Navigation.NavigationStack.Skip(pageOffset).FirstOrDefault();
+        currentPage.Navigation.InsertPageBefore(page, firstPage);
+        return Task.FromResult(true);
+    }
 
-        protected virtual Task<Page> DoPop(INavigation navigation, bool useModalNavigation, bool animated)
-        {
-            if (useModalNavigation)
-                return navigation.PopModalAsync(animated);
-            else
-                return navigation.PopAsync(animated);
-        }
+    protected virtual Task<Page> DoPop(INavigation navigation, bool useModalNavigation, bool animated)
+    {
+        if (useModalNavigation)
+            return navigation.PopModalAsync(animated);
+        else
+            return navigation.PopAsync(animated);
+    }
 
-        protected virtual Page GetCurrentPage()
-        {
-            return _page != null ? _page : GetPageFromWindow();
-        }
+    protected virtual Page GetCurrentPage()
+    {
+        return _page != null ? _page : GetPageFromWindow();
+    }
 
-        internal static bool UseModalNavigation(Page currentPage, bool? useModalNavigationDefault)
-        {
-            bool useModalNavigation = true;
+    internal static bool UseModalNavigation(Page currentPage, bool? useModalNavigationDefault)
+    {
+        bool useModalNavigation = true;
 
-            if (useModalNavigationDefault.HasValue)
-                useModalNavigation = useModalNavigationDefault.Value;
-            else if (currentPage is NavigationPage)
-                useModalNavigation = false;
-            else
-                useModalNavigation = !PageUtilities.HasNavigationPageParent(currentPage);
+        if (useModalNavigationDefault.HasValue)
+            useModalNavigation = useModalNavigationDefault.Value;
+        else if (currentPage is NavigationPage)
+            useModalNavigation = false;
+        else
+            useModalNavigation = !PageUtilities.HasNavigationPageParent(currentPage);
 
-            return useModalNavigation;
-        }
+        return useModalNavigation;
+    }
 
-        internal bool UseModalGoBack(Page currentPage, bool? useModalNavigationDefault)
-        {
-            if (useModalNavigationDefault.HasValue)
-                return useModalNavigationDefault.Value;
-            else if (currentPage is NavigationPage navPage)
-                return GoBackModal(navPage);
-            else if (PageUtilities.HasNavigationPageParent(currentPage, out var navParent))
-                return GoBackModal(navParent);
-            else
-                return true;
-        }
+    internal bool UseModalGoBack(Page currentPage, bool? useModalNavigationDefault)
+    {
+        if (useModalNavigationDefault.HasValue)
+            return useModalNavigationDefault.Value;
+        else if (currentPage is NavigationPage navPage)
+            return GoBackModal(navPage);
+        else if (PageUtilities.HasNavigationPageParent(currentPage, out var navParent))
+            return GoBackModal(navParent);
+        else
+            return true;
+    }
 
-        private bool GoBackModal(NavigationPage navPage)
-        {
-            var rootPage = GetPageFromWindow();
-            if (navPage.CurrentPage != navPage.RootPage)
-                return false;
-            else if (navPage.CurrentPage == navPage.RootPage && navPage.Parent is Application && rootPage != navPage)
-                return true;
-            else if (navPage.Parent is TabbedPage tabbed && tabbed != rootPage)
-                return true;
-
+    private bool GoBackModal(NavigationPage navPage)
+    {
+        var rootPage = GetPageFromWindow();
+        if (navPage.CurrentPage != navPage.RootPage)
             return false;
-        }
+        else if (navPage.CurrentPage == navPage.RootPage && navPage.Parent is Application && rootPage != navPage)
+            return true;
+        else if (navPage.Parent is TabbedPage tabbed && tabbed != rootPage)
+            return true;
 
-        internal static bool UseReverseNavigation(Page currentPage, Type nextPageType)
+        return false;
+    }
+
+    internal static bool UseReverseNavigation(Page currentPage, Type nextPageType)
+    {
+        return PageUtilities.HasNavigationPageParent(currentPage) && PageUtilities.IsSameOrSubclassOf<ContentPage>(nextPageType);
+    }
+
+    protected static bool IsRoot(Page mainPage, Page currentPage)
+    {
+        if (mainPage == currentPage)
+            return true;
+
+        return mainPage switch
         {
-            return PageUtilities.HasNavigationPageParent(currentPage) && PageUtilities.IsSameOrSubclassOf<ContentPage>(nextPageType);
-        }
+            FlyoutPage fp => IsRoot(fp.Detail, currentPage),
+            TabbedPage tp => IsRoot(tp.CurrentPage, currentPage),
+            NavigationPage np => IsRoot(np.RootPage, currentPage),
+            _ => false
+        };
+    }
 
-        protected static bool IsRoot(Page mainPage, Page currentPage)
+    private Page GetPageFromWindow()
+    {
+        try
         {
-            if (mainPage == currentPage)
-                return true;
-
-            return mainPage switch
-            {
-                FlyoutPage fp => IsRoot(fp.Detail, currentPage),
-                TabbedPage tp => IsRoot(tp.CurrentPage, currentPage),
-                NavigationPage np => IsRoot(np.RootPage, currentPage),
-                _ => false
-            };
+            return Window?.Page;
         }
-
-        private Page GetPageFromWindow()
-        {
-            try
-            {
-                return Window?.Page;
-            }
 #if DEBUG
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(ex);
-                return null;
-            }
-#else
-            catch
-            {
-                return null;
-            }
-#endif
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            return null;
         }
+#else
+        catch
+        {
+            return null;
+        }
+#endif
     }
 }

--- a/src/Prism.Maui/Navigation/PageNavigationSource.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationSource.cs
@@ -1,8 +1,7 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+public enum PageNavigationSource
 {
-    public enum PageNavigationSource
-    {
-        NavigationService,
-        Device
-    }
+    NavigationService,
+    Device
 }

--- a/src/Prism.Maui/Navigation/ViewRegistration.cs
+++ b/src/Prism.Maui/Navigation/ViewRegistration.cs
@@ -1,9 +1,8 @@
-﻿namespace Prism.Navigation
+﻿namespace Prism.Navigation;
+
+public record ViewRegistration
 {
-    public record ViewRegistration
-    {
-        public Type View { get; init; }
-        public Type ViewModel { get; init; }
-        public string Name { get; init; }
-    }
+    public Type View { get; init; }
+    public Type ViewModel { get; init; }
+    public string Name { get; init; }
 }

--- a/src/Prism.Maui/Navigation/Xaml/Navigation.cs
+++ b/src/Prism.Maui/Navigation/Xaml/Navigation.cs
@@ -3,137 +3,136 @@ using Microsoft.Maui.Controls;
 using Prism.Common;
 using Prism.Ioc;
 
-namespace Prism.Navigation.Xaml
+namespace Prism.Navigation.Xaml;
+
+/// <summary>
+/// Provides Attachable properties for Navigation
+/// </summary>
+public static class Navigation
 {
-    /// <summary>
-    /// Provides Attachable properties for Navigation
-    /// </summary>
-    public static class Navigation
+    internal static readonly BindableProperty NavigationServiceProperty =
+        BindableProperty.CreateAttached("NavigationService",
+            typeof(INavigationService),
+            typeof(Navigation),
+            default(INavigationService));
+
+    internal static readonly BindableProperty NavigationScopeProperty =
+        BindableProperty.CreateAttached("NavigationScope",
+            typeof(IScopedProvider),
+            typeof(Navigation),
+            default(IScopedProvider),
+            propertyChanged: OnNavigationScopeChanged);
+
+    private static void OnNavigationScopeChanged(BindableObject bindable, object oldValue, object newValue)
     {
-        internal static readonly BindableProperty NavigationServiceProperty =
-            BindableProperty.CreateAttached("NavigationService",
-                typeof(INavigationService),
-                typeof(Navigation),
-                default(INavigationService));
-
-        internal static readonly BindableProperty NavigationScopeProperty =
-            BindableProperty.CreateAttached("NavigationScope",
-                typeof(IScopedProvider),
-                typeof(Navigation),
-                default(IScopedProvider),
-                propertyChanged: OnNavigationScopeChanged);
-
-        private static void OnNavigationScopeChanged(BindableObject bindable, object oldValue, object newValue)
+        if (oldValue == newValue)
         {
-            if (oldValue == newValue)
-            {
-                return;
-            }
-
-            if (oldValue != null && newValue is null && oldValue is IScopedProvider oldProvider)
-            {
-                oldProvider.Dispose();
-                return;
-            }
-
-            if (newValue != null && newValue is IScopedProvider scopedProvider)
-            {
-                scopedProvider.IsAttached = true;
-            }
+            return;
         }
 
-        /// <summary>
-        /// Provides bindable CanNavigate Bindable Property
-        /// </summary>
-        public static readonly BindableProperty CanNavigateProperty =
-            BindableProperty.CreateAttached("CanNavigate",
-                typeof(bool),
-                typeof(Navigation),
-                true,
-                propertyChanged: OnCanNavigatePropertyChanged);
-
-        internal static readonly BindableProperty RaiseCanExecuteChangedInternalProperty =
-            BindableProperty.CreateAttached("RaiseCanExecuteChangedInternal",
-                typeof(Action),
-                typeof(Navigation),
-                default(Action));
-
-        /// <summary>
-        /// Gets the Bindable Can Navigate property for an element
-        /// </summary>
-        /// <param name="view">The bindable element</param>
-        public static bool GetCanNavigate(BindableObject view) => (bool)view.GetValue(CanNavigateProperty);
-
-        /// <summary>
-        /// Sets the Bindable Can Navigate property for an element
-        /// </summary>
-        /// <param name="view">The bindable element</param>
-        /// <param name="value">The Can Navigate value</param>
-        public static void SetCanNavigate(BindableObject view, bool value) => view.SetValue(CanNavigateProperty, value);
-
-        /// <summary>
-        /// Gets the instance of <see cref="INavigationService"/> for the given <see cref="Page"/>
-        /// </summary>
-        /// <param name="page">The <see cref="Page"/></param>
-        /// <returns>The <see cref="INavigationService"/></returns>
-        /// <remarks>Do not use... this is an internal use API</remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static INavigationService GetNavigationService(Page page)
+        if (oldValue != null && newValue is null && oldValue is IScopedProvider oldProvider)
         {
-            if (page == null) throw new ArgumentNullException(nameof(page));
-
-            var container = ContainerLocator.Container;
-            var navService = (INavigationService)page.GetValue(NavigationServiceProperty);
-            if (navService is null)
-            {
-                var currentScope = (IScopedProvider)page.GetValue(NavigationScopeProperty) ?? container.CurrentScope;
-
-                if (currentScope is null)
-                    currentScope = container.CreateScope();
-
-                if (!currentScope.IsAttached)
-                    page.SetValue(NavigationScopeProperty, currentScope);
-
-                navService = CreateNavigationService(currentScope, page);
-            }
-            else if (navService is IPageAware pa && pa.Page != page)
-            {
-                var scope = container.CreateScope();
-                page.SetValue(NavigationScopeProperty, scope);
-                page.SetValue(NavigationServiceProperty, null);
-                return GetNavigationService(page);
-            }
-
-            return navService;
+            oldProvider.Dispose();
+            return;
         }
 
-        private static INavigationService CreateNavigationService(IScopedProvider scope, Page page)
+        if (newValue != null && newValue is IScopedProvider scopedProvider)
         {
-            var navService = scope.Resolve<INavigationService>();
-            switch (navService)
-            {
-                case IPageAware pa when pa.Page is null:
-                    pa.Page = page;
-                    break;
-                case IPageAware pa1 when pa1.Page != page:
-                    return CreateNavigationService(ContainerLocator.Container.CreateScope(), page);
-            }
+            scopedProvider.IsAttached = true;
+        }
+    }
 
+    /// <summary>
+    /// Provides bindable CanNavigate Bindable Property
+    /// </summary>
+    public static readonly BindableProperty CanNavigateProperty =
+        BindableProperty.CreateAttached("CanNavigate",
+            typeof(bool),
+            typeof(Navigation),
+            true,
+            propertyChanged: OnCanNavigatePropertyChanged);
+
+    internal static readonly BindableProperty RaiseCanExecuteChangedInternalProperty =
+        BindableProperty.CreateAttached("RaiseCanExecuteChangedInternal",
+            typeof(Action),
+            typeof(Navigation),
+            default(Action));
+
+    /// <summary>
+    /// Gets the Bindable Can Navigate property for an element
+    /// </summary>
+    /// <param name="view">The bindable element</param>
+    public static bool GetCanNavigate(BindableObject view) => (bool)view.GetValue(CanNavigateProperty);
+
+    /// <summary>
+    /// Sets the Bindable Can Navigate property for an element
+    /// </summary>
+    /// <param name="view">The bindable element</param>
+    /// <param name="value">The Can Navigate value</param>
+    public static void SetCanNavigate(BindableObject view, bool value) => view.SetValue(CanNavigateProperty, value);
+
+    /// <summary>
+    /// Gets the instance of <see cref="INavigationService"/> for the given <see cref="Page"/>
+    /// </summary>
+    /// <param name="page">The <see cref="Page"/></param>
+    /// <returns>The <see cref="INavigationService"/></returns>
+    /// <remarks>Do not use... this is an internal use API</remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static INavigationService GetNavigationService(Page page)
+    {
+        if (page == null) throw new ArgumentNullException(nameof(page));
+
+        var container = ContainerLocator.Container;
+        var navService = (INavigationService)page.GetValue(NavigationServiceProperty);
+        if (navService is null)
+        {
+            var currentScope = (IScopedProvider)page.GetValue(NavigationScopeProperty) ?? container.CurrentScope;
+
+            if (currentScope is null)
+                currentScope = container.CreateScope();
+
+            if (!currentScope.IsAttached)
+                page.SetValue(NavigationScopeProperty, currentScope);
+
+            navService = CreateNavigationService(currentScope, page);
+        }
+        else if (navService is IPageAware pa && pa.Page != page)
+        {
+            var scope = container.CreateScope();
             page.SetValue(NavigationScopeProperty, scope);
-            scope.IsAttached = true;
-            page.SetValue(NavigationServiceProperty, navService);
-
-            return navService;
+            page.SetValue(NavigationServiceProperty, null);
+            return GetNavigationService(page);
         }
 
-        internal static Action GetRaiseCanExecuteChangedInternal(BindableObject view) => (Action)view.GetValue(RaiseCanExecuteChangedInternalProperty);
+        return navService;
+    }
 
-        internal static void SetRaiseCanExecuteChangedInternal(BindableObject view, Action value) => view.SetValue(RaiseCanExecuteChangedInternalProperty, value);
-
-        private static void OnCanNavigatePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+    private static INavigationService CreateNavigationService(IScopedProvider scope, Page page)
+    {
+        var navService = scope.Resolve<INavigationService>();
+        switch (navService)
         {
-            var action = GetRaiseCanExecuteChangedInternal(bindable);
-            action?.Invoke();
+            case IPageAware pa when pa.Page is null:
+                pa.Page = page;
+                break;
+            case IPageAware pa1 when pa1.Page != page:
+                return CreateNavigationService(ContainerLocator.Container.CreateScope(), page);
         }
+
+        page.SetValue(NavigationScopeProperty, scope);
+        scope.IsAttached = true;
+        page.SetValue(NavigationServiceProperty, navService);
+
+        return navService;
+    }
+
+    internal static Action GetRaiseCanExecuteChangedInternal(BindableObject view) => (Action)view.GetValue(RaiseCanExecuteChangedInternalProperty);
+
+    internal static void SetRaiseCanExecuteChangedInternal(BindableObject view, Action value) => view.SetValue(RaiseCanExecuteChangedInternalProperty, value);
+
+    private static void OnCanNavigatePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+    {
+        var action = GetRaiseCanExecuteChangedInternal(bindable);
+        action?.Invoke();
     }
 }

--- a/src/Prism.Maui/Properties/AssemblyInfo.cs
+++ b/src/Prism.Maui/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism")]
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Behaviors")]
+[assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Controls")]
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Ioc")]
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Modularity")]
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Mvvm")]

--- a/src/Prism.Maui/Services/Dialogs/DialogParameters.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogParameters.cs
@@ -1,16 +1,15 @@
 ﻿using Prism.Common;
 
-namespace Prism.Services.Dialogs
-{
-    public class DialogParameters : ParametersBase, IDialogParameters
-    {
-        public DialogParameters()
-        {
-        }
+namespace Prism.Services.Dialogs;
 
-        public DialogParameters(string query)
-            : base(query)
-        {
-        }
+public class DialogParameters : ParametersBase, IDialogParameters
+{
+    public DialogParameters()
+    {
+    }
+
+    public DialogParameters(string query)
+        : base(query)
+    {
     }
 }

--- a/src/Prism.Maui/Services/Dialogs/DialogResult.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogResult.cs
@@ -1,8 +1,7 @@
-﻿namespace Prism.Services.Dialogs
+﻿namespace Prism.Services.Dialogs;
+
+public record DialogResult : IDialogResult
 {
-    public record DialogResult : IDialogResult
-    {
-        public Exception Exception { get; init; }
-        public IDialogParameters Parameters { get; init; }
-    }
+    public Exception Exception { get; init; }
+    public IDialogParameters Parameters { get; init; }
 }

--- a/src/Prism.Maui/Services/Dialogs/IDialogParameters.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogParameters.cs
@@ -1,11 +1,10 @@
 ﻿using Prism.Common;
 
-namespace Prism.Services.Dialogs
+namespace Prism.Services.Dialogs;
+
+/// <summary>
+/// Provides a way for the <see cref="IDialogService"/> to pass parameters when displaying a dialog.
+/// </summary>
+public interface IDialogParameters : IParameters
 {
-    /// <summary>
-    /// Provides a way for the <see cref="IDialogService"/> to pass parameters when displaying a dialog.
-    /// </summary>
-    public interface IDialogParameters : IParameters
-    {
-    }
 }

--- a/src/Prism.Maui/Services/Dialogs/IDialogResult.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogResult.cs
@@ -1,8 +1,7 @@
-﻿namespace Prism.Services.Dialogs
+﻿namespace Prism.Services.Dialogs;
+
+public interface IDialogResult
 {
-    public interface IDialogResult
-    {
-        Exception Exception { get; }
-        IDialogParameters Parameters { get; }
-    }
+    Exception Exception { get; }
+    IDialogParameters Parameters { get; }
 }

--- a/src/Prism.Maui/Services/Dialogs/IDialogService.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogService.cs
@@ -1,27 +1,26 @@
-﻿namespace Prism.Services.Dialogs
+﻿namespace Prism.Services.Dialogs;
+
+/// <summary>
+/// Defines a contract for displaying dialogs from ViewModels.
+/// </summary>
+public interface IDialogService
 {
     /// <summary>
-    /// Defines a contract for displaying dialogs from ViewModels.
+    /// Displays a dialog.
     /// </summary>
-    public interface IDialogService
-    {
-        /// <summary>
-        /// Displays a dialog.
-        /// </summary>
-        /// <param name="name">The unique name of the dialog to display. Must match an entry in the <see cref="Prism.Ioc.IContainerRegistry"/>.</param>
-        /// <param name="parameters">Parameters that the dialog can use for custom functionality.</param>
-        /// <param name="callback">The action to be invoked upon successful or failed completion of displaying the dialog.</param>
-        /// <example>
-        /// This example shows how to display a dialog with two parameters.
-        /// <code>
-        /// var parameters = new DialogParameters
-        /// {
-        ///     { "title", "Connection Lost!" },
-        ///     { "message", "We seem to have lost network connectivity" }
-        /// };
-        /// _dialogService.ShowDialog("DemoDialog", parameters, <paramref name="callback"/>: null);
-        /// </code>
-        /// </example>
-        void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback);
-    }
+    /// <param name="name">The unique name of the dialog to display. Must match an entry in the <see cref="Prism.Ioc.IContainerRegistry"/>.</param>
+    /// <param name="parameters">Parameters that the dialog can use for custom functionality.</param>
+    /// <param name="callback">The action to be invoked upon successful or failed completion of displaying the dialog.</param>
+    /// <example>
+    /// This example shows how to display a dialog with two parameters.
+    /// <code>
+    /// var parameters = new DialogParameters
+    /// {
+    ///     { "title", "Connection Lost!" },
+    ///     { "message", "We seem to have lost network connectivity" }
+    /// };
+    /// _dialogService.ShowDialog("DemoDialog", parameters, <paramref name="callback"/>: null);
+    /// </code>
+    /// </example>
+    void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback);
 }

--- a/src/Prism.Maui/Services/PageDialogs/ActionSheetButton.cs
+++ b/src/Prism.Maui/Services/PageDialogs/ActionSheetButton.cs
@@ -1,181 +1,180 @@
-﻿namespace Prism.Services
+﻿namespace Prism.Services;
+
+/// <summary>
+/// Represents a button displayed in <see cref="IPageDialogService.DisplayActionSheetAsync(string, IActionSheetButton[])"/>
+/// </summary>
+public class ActionSheetButton : ActionSheetButtonBase
 {
-    /// <summary>
-    /// Represents a button displayed in <see cref="IPageDialogService.DisplayActionSheetAsync(string, IActionSheetButton[])"/>
-    /// </summary>
-    public class ActionSheetButton : ActionSheetButtonBase
+    protected internal ActionSheetButton()
     {
-        protected internal ActionSheetButton()
-        {
 
-        }
-
-        /// <summary>
-        /// Action to perform when the button is pressed
-        /// </summary>
-        /// <value>The action.</value>
-        public Action Action { get; protected set; }
-
-        public Func<Task> AsyncCallback { get; protected set; }
-
-        /// <summary>
-        /// Executes the action to take when the button is pressed
-        /// </summary>
-        protected override async Task OnButtonPressed()
-        {
-            Action?.Invoke();
-            if (AsyncCallback != null)
-                await AsyncCallback();
-        }
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateCancelButton(string text) => CreateCancelButton(text, default);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="action">Action to execute when button pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateCancelButton(string text, Action action) =>
-            CreateButtonInternal(text, action, null, isCancel: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="asyncCallback">Action to execute when button pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateCancelButton(string text, Func<Task> asyncCallback) =>
-            CreateButtonInternal(text, null, asyncCallback, isCancel: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="action">Action to execute when button pressed</param>
-        /// <param name="parameter">Parameter to pass the Action when the button is pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateCancelButton<T>(string text, Action<T> action, T parameter) =>
-            CreateButtonInternal(text, action, null, parameter, isCancel: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="asyncCallback">Action to execute when button pressed</param>
-        /// <param name="parameter">Parameter to pass the Action when the button is pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateCancelButton<T>(string text, Func<T, Task> asyncCallback, T parameter) =>
-            CreateButtonInternal(text, null, asyncCallback, parameter, isCancel: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateDestroyButton(string text) =>
-            CreateDestroyButton(text, default);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="action">Action to execute when button pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateDestroyButton(string text, Action action) =>
-            CreateButtonInternal(text, action, null, isDestroy: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="asyncCallback">Action to execute when button pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateDestroyButton(string text, Func<Task> asyncCallback) =>
-            CreateButtonInternal(text, null, asyncCallback, isDestroy: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="action">Action to execute when button pressed</param>
-        /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateDestroyButton<T>(string text, Action<T> action, T parameter) =>
-            CreateButtonInternal(text, action, null, parameter, isDestroy: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="asyncCallback">Action to execute when button pressed</param>
-        /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateDestroyButton<T>(string text, Func<T, Task> asyncCallback, T parameter) =>
-            CreateButtonInternal(text, null, asyncCallback, parameter, isDestroy: true);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="action">Action to execute when button pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateButton(string text, Action action) =>
-            CreateButtonInternal(text, action, null);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="asyncCallback">Action to execute when button pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateButton(string text, Func<Task> asyncCallback) =>
-            CreateButtonInternal(text, null, asyncCallback);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="action">Action to execute when button pressed</param>
-        /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateButton<T>(string text, Action<T> action, T parameter) =>
-            CreateButtonInternal(text, action, null, parameter);
-
-        /// <summary>
-        /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
-        /// </summary>
-        /// <param name="text">Button text</param>
-        /// <param name="asyncCallback">Action to execute when button pressed</param>
-        /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
-        /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
-        public static IActionSheetButton CreateButton<T>(string text, Func<T, Task> asyncCallback, T parameter) =>
-            CreateButtonInternal(text, null, asyncCallback, parameter);
-
-        private static IActionSheetButton CreateButtonInternal(string text, Action action, Func<Task> asyncCallback, bool isCancel = false, bool isDestroy = false) =>
-            new ActionSheetButton()
-            {
-                Text = text,
-                Action = action,
-                AsyncCallback = asyncCallback,
-                IsCancel = isCancel,
-                IsDestroy = isDestroy,
-            };
-
-        private static IActionSheetButton CreateButtonInternal<T>(string text, Action<T> action, Func<T, Task> asyncCallback, T parameter, bool isCancel = false, bool isDestroy = false) =>
-            new ActionSheetButton<T>()
-            {
-                Text = text,
-                Action = action,
-                AsyncCallback = asyncCallback,
-                Parameter = parameter,
-                IsCancel = isCancel,
-                IsDestroy = isDestroy,
-            };
     }
+
+    /// <summary>
+    /// Action to perform when the button is pressed
+    /// </summary>
+    /// <value>The action.</value>
+    public Action Action { get; protected set; }
+
+    public Func<Task> AsyncCallback { get; protected set; }
+
+    /// <summary>
+    /// Executes the action to take when the button is pressed
+    /// </summary>
+    protected override async Task OnButtonPressed()
+    {
+        Action?.Invoke();
+        if (AsyncCallback != null)
+            await AsyncCallback();
+    }
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateCancelButton(string text) => CreateCancelButton(text, default);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="action">Action to execute when button pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateCancelButton(string text, Action action) =>
+        CreateButtonInternal(text, action, null, isCancel: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="asyncCallback">Action to execute when button pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateCancelButton(string text, Func<Task> asyncCallback) =>
+        CreateButtonInternal(text, null, asyncCallback, isCancel: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="action">Action to execute when button pressed</param>
+    /// <param name="parameter">Parameter to pass the Action when the button is pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateCancelButton<T>(string text, Action<T> action, T parameter) =>
+        CreateButtonInternal(text, action, null, parameter, isCancel: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "cancel button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="asyncCallback">Action to execute when button pressed</param>
+    /// <param name="parameter">Parameter to pass the Action when the button is pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateCancelButton<T>(string text, Func<T, Task> asyncCallback, T parameter) =>
+        CreateButtonInternal(text, null, asyncCallback, parameter, isCancel: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateDestroyButton(string text) =>
+        CreateDestroyButton(text, default);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="action">Action to execute when button pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateDestroyButton(string text, Action action) =>
+        CreateButtonInternal(text, action, null, isDestroy: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="asyncCallback">Action to execute when button pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateDestroyButton(string text, Func<Task> asyncCallback) =>
+        CreateButtonInternal(text, null, asyncCallback, isDestroy: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="action">Action to execute when button pressed</param>
+    /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateDestroyButton<T>(string text, Action<T> action, T parameter) =>
+        CreateButtonInternal(text, action, null, parameter, isDestroy: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "destroy button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="asyncCallback">Action to execute when button pressed</param>
+    /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateDestroyButton<T>(string text, Func<T, Task> asyncCallback, T parameter) =>
+        CreateButtonInternal(text, null, asyncCallback, parameter, isDestroy: true);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="action">Action to execute when button pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateButton(string text, Action action) =>
+        CreateButtonInternal(text, action, null);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="asyncCallback">Action to execute when button pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateButton(string text, Func<Task> asyncCallback) =>
+        CreateButtonInternal(text, null, asyncCallback);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="action">Action to execute when button pressed</param>
+    /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateButton<T>(string text, Action<T> action, T parameter) =>
+        CreateButtonInternal(text, action, null, parameter);
+
+    /// <summary>
+    /// Create a new instance of <see cref="ActionSheetButton"/> that display as "other button"
+    /// </summary>
+    /// <param name="text">Button text</param>
+    /// <param name="asyncCallback">Action to execute when button pressed</param>
+    /// <param name="parameter">Parameter to pass the action when the button is pressed</param>
+    /// <returns>An instance of <see cref="ActionSheetButton"/></returns>
+    public static IActionSheetButton CreateButton<T>(string text, Func<T, Task> asyncCallback, T parameter) =>
+        CreateButtonInternal(text, null, asyncCallback, parameter);
+
+    private static IActionSheetButton CreateButtonInternal(string text, Action action, Func<Task> asyncCallback, bool isCancel = false, bool isDestroy = false) =>
+        new ActionSheetButton()
+        {
+            Text = text,
+            Action = action,
+            AsyncCallback = asyncCallback,
+            IsCancel = isCancel,
+            IsDestroy = isDestroy,
+        };
+
+    private static IActionSheetButton CreateButtonInternal<T>(string text, Action<T> action, Func<T, Task> asyncCallback, T parameter, bool isCancel = false, bool isDestroy = false) =>
+        new ActionSheetButton<T>()
+        {
+            Text = text,
+            Action = action,
+            AsyncCallback = asyncCallback,
+            Parameter = parameter,
+            IsCancel = isCancel,
+            IsDestroy = isDestroy,
+        };
 }

--- a/src/Prism.Maui/Services/PageDialogs/ActionSheetButtonBase.cs
+++ b/src/Prism.Maui/Services/PageDialogs/ActionSheetButtonBase.cs
@@ -1,89 +1,88 @@
-﻿namespace Prism.Services
+﻿namespace Prism.Services;
+
+/// <summary>
+/// ActionSheetButton Base class
+/// </summary>
+public abstract class ActionSheetButtonBase : IActionSheetButton
 {
-    /// <summary>
-    /// ActionSheetButton Base class
-    /// </summary>
-    public abstract class ActionSheetButtonBase : IActionSheetButton
+    protected ActionSheetButtonBase()
     {
-        protected ActionSheetButtonBase()
-        {
 
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether this <see cref="IActionSheetButton"/>
-        /// is cancel.
-        /// </summary>
-        /// <value><c>true</c> if is cancel; otherwise, <c>false</c>.</value>
-        protected bool _isCancel { get; private set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this <see cref="IActionSheetButton"/>
-        /// is destroy.
-        /// </summary>
-        /// <value><c>true</c> if is destroy; otherwise, <c>false</c>.</value>
-        protected bool _isDestroy { get; private set; }
-
-        /// <summary>
-        /// The backing text for <see cref="IActionSheetButton"/>
-        /// </summary>
-        /// <value>The text.</value>
-        protected string _text { get; private set; }
-
-        /// <summary>
-        /// The button will be used as a Cancel Button
-        /// </summary>
-        /// <value><c>true</c> if is cancel; otherwise, <c>false</c>.</value>
-        public bool IsCancel
-        {
-            get => _isCancel;
-            protected internal set
-            {
-                if (_isCancel = value)
-                    IsDestroy = false;
-            }
-        }
-
-        /// <summary>
-        /// The button will be used as a Destroy Button
-        /// </summary>
-        /// <value><c>true</c> if is destroy; otherwise, <c>false</c>.</value>
-        public bool IsDestroy
-        {
-            get => _isDestroy;
-            protected internal set
-            {
-                if (_isDestroy = value)
-                    IsCancel = false;
-            }
-        }
-
-        /// <summary>
-        /// Executes the action to take when the button is pressed
-        /// </summary>
-        /// <value>The text.</value>
-        public string Text
-        {
-            get => _text;
-            protected internal set => _text = value;
-        }
-
-        /// <summary>
-        /// Executes the action.
-        /// </summary>
-        protected abstract Task OnButtonPressed();
-
-        /// <inheritDoc />
-        bool IActionSheetButton.IsCancel => _isCancel;
-
-        /// <inheritDoc />
-        bool IActionSheetButton.IsDestroy => _isDestroy;
-
-        /// <inheritDoc />
-        string IActionSheetButton.Text => _text;
-
-        /// <inheritDoc />
-        Task IActionSheetButton.PressButton() =>
-           OnButtonPressed();
     }
+
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="IActionSheetButton"/>
+    /// is cancel.
+    /// </summary>
+    /// <value><c>true</c> if is cancel; otherwise, <c>false</c>.</value>
+    protected bool _isCancel { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="IActionSheetButton"/>
+    /// is destroy.
+    /// </summary>
+    /// <value><c>true</c> if is destroy; otherwise, <c>false</c>.</value>
+    protected bool _isDestroy { get; private set; }
+
+    /// <summary>
+    /// The backing text for <see cref="IActionSheetButton"/>
+    /// </summary>
+    /// <value>The text.</value>
+    protected string _text { get; private set; }
+
+    /// <summary>
+    /// The button will be used as a Cancel Button
+    /// </summary>
+    /// <value><c>true</c> if is cancel; otherwise, <c>false</c>.</value>
+    public bool IsCancel
+    {
+        get => _isCancel;
+        protected internal set
+        {
+            if (_isCancel = value)
+                IsDestroy = false;
+        }
+    }
+
+    /// <summary>
+    /// The button will be used as a Destroy Button
+    /// </summary>
+    /// <value><c>true</c> if is destroy; otherwise, <c>false</c>.</value>
+    public bool IsDestroy
+    {
+        get => _isDestroy;
+        protected internal set
+        {
+            if (_isDestroy = value)
+                IsCancel = false;
+        }
+    }
+
+    /// <summary>
+    /// Executes the action to take when the button is pressed
+    /// </summary>
+    /// <value>The text.</value>
+    public string Text
+    {
+        get => _text;
+        protected internal set => _text = value;
+    }
+
+    /// <summary>
+    /// Executes the action.
+    /// </summary>
+    protected abstract Task OnButtonPressed();
+
+    /// <inheritDoc />
+    bool IActionSheetButton.IsCancel => _isCancel;
+
+    /// <inheritDoc />
+    bool IActionSheetButton.IsDestroy => _isDestroy;
+
+    /// <inheritDoc />
+    string IActionSheetButton.Text => _text;
+
+    /// <inheritDoc />
+    Task IActionSheetButton.PressButton() =>
+       OnButtonPressed();
 }

--- a/src/Prism.Maui/Services/PageDialogs/ActionSheetButton{T}.cs
+++ b/src/Prism.Maui/Services/PageDialogs/ActionSheetButton{T}.cs
@@ -1,37 +1,36 @@
-﻿namespace Prism.Services
+﻿namespace Prism.Services;
+
+/// <summary>
+/// Provides a Generic Implementation for IActionSheetButton
+/// </summary>
+public class ActionSheetButton<T> : ActionSheetButtonBase
 {
-    /// <summary>
-    /// Provides a Generic Implementation for IActionSheetButton
-    /// </summary>
-    public class ActionSheetButton<T> : ActionSheetButtonBase
+    protected internal ActionSheetButton()
     {
-        protected internal ActionSheetButton()
-        {
 
-        }
+    }
 
-        /// <summary>
-        /// Generic Action to perform
-        /// </summary>
-        /// <value>The action.</value>
-        public Action<T> Action { get; set; }
+    /// <summary>
+    /// Generic Action to perform
+    /// </summary>
+    /// <value>The action.</value>
+    public Action<T> Action { get; set; }
 
-        public Func<T, Task> AsyncCallback { get; set; }
+    public Func<T, Task> AsyncCallback { get; set; }
 
-        /// <summary>
-        /// Typed Parameter
-        /// </summary>
-        /// <value>The parameter.</value>
-        public T Parameter { get; set; }
+    /// <summary>
+    /// Typed Parameter
+    /// </summary>
+    /// <value>The parameter.</value>
+    public T Parameter { get; set; }
 
-        /// <summary>
-        /// Executes the action to take when the button is pressed
-        /// </summary>
-        protected override async Task OnButtonPressed()
-        {
-            Action?.Invoke(Parameter);
-            if (AsyncCallback != null)
-                await AsyncCallback(Parameter);
-        }
+    /// <summary>
+    /// Executes the action to take when the button is pressed
+    /// </summary>
+    protected override async Task OnButtonPressed()
+    {
+        Action?.Invoke(Parameter);
+        if (AsyncCallback != null)
+            await AsyncCallback(Parameter);
     }
 }

--- a/src/Prism.Maui/Services/PageDialogs/IActionSheetButton.cs
+++ b/src/Prism.Maui/Services/PageDialogs/IActionSheetButton.cs
@@ -1,28 +1,27 @@
-﻿namespace Prism.Services
+﻿namespace Prism.Services;
+
+/// <summary>
+/// Convenient contract to enable executing commands directly when using <see cref="IPageDialogService.DisplayActionSheetAsync(string, IActionSheetButton[])"/>
+/// </summary>
+public interface IActionSheetButton
 {
     /// <summary>
-    /// Convenient contract to enable executing commands directly when using <see cref="IPageDialogService.DisplayActionSheetAsync(string, IActionSheetButton[])"/>
+    /// The button will be used as destroy
     /// </summary>
-    public interface IActionSheetButton
-    {
-        /// <summary>
-        /// The button will be used as destroy
-        /// </summary>
-        bool IsDestroy { get; }
+    bool IsDestroy { get; }
 
-        /// <summary>
-        /// The button will be used as cancel
-        /// </summary>
-        bool IsCancel { get; }
+    /// <summary>
+    /// The button will be used as cancel
+    /// </summary>
+    bool IsCancel { get; }
 
-        /// <summary>
-        /// Text to display in the action sheet
-        /// </summary>
-        string Text { get; }
+    /// <summary>
+    /// Text to display in the action sheet
+    /// </summary>
+    string Text { get; }
 
-        /// <summary>
-        /// Presses the button.
-        /// </summary>
-        Task PressButton();
-    }
+    /// <summary>
+    /// Presses the button.
+    /// </summary>
+    Task PressButton();
 }

--- a/src/Prism.Maui/Services/PageDialogs/IPageDialogService.cs
+++ b/src/Prism.Maui/Services/PageDialogs/IPageDialogService.cs
@@ -1,123 +1,122 @@
 ﻿using Prism.AppModel;
 using FlowDirection = Prism.AppModel.FlowDirection;
 
-namespace Prism.Services
+namespace Prism.Services;
+
+/// <summary>
+/// A service which provides access to the DisplayAlert and DisplayActionSheet off of the Microsoft.Maui.Controls.Page class.
+/// </summary>
+public interface IPageDialogService
 {
     /// <summary>
-    /// A service which provides access to the DisplayAlert and DisplayActionSheet off of the Microsoft.Maui.Controls.Page class.
+    /// Presents an alert dialog to the application user with an accept and a cancel button.
     /// </summary>
-    public interface IPageDialogService
-    {
-        /// <summary>
-        /// Presents an alert dialog to the application user with an accept and a cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="acceptButton">Text for the accept button.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
-        Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton);
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="acceptButton">Text for the accept button.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
+    Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton);
 
-        /// <summary>
-        /// Presents an alert dialog to the application user with an accept and a cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="acceptButton">Text for the accept button.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
-        Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection);
+    /// <summary>
+    /// Presents an alert dialog to the application user with an accept and a cancel button.
+    /// </summary>
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="acceptButton">Text for the accept button.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
+    Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection);
 
-        /// <summary>
-        /// Presents an alert dialog to the application user with a single cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <returns></returns>
-        Task DisplayAlertAsync(string title, string message, string cancelButton);
+    /// <summary>
+    /// Presents an alert dialog to the application user with a single cancel button.
+    /// </summary>
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <returns></returns>
+    Task DisplayAlertAsync(string title, string message, string cancelButton);
 
-        /// <summary>
-        /// Presents an alert dialog to the application user with a single cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <returns></returns>
-        Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection);
+    /// <summary>
+    /// Presents an alert dialog to the application user with a single cancel button.
+    /// </summary>
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <returns></returns>
+    Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection);
 
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <param name="title">Title to display in view.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="destroyButton">Text for the ok button.</param>
-        /// <param name="otherButtons">Text for other buttons.</param>
-        /// <returns>Text for the pressed button</returns>
-        Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, params string[] otherButtons);
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <param name="title">Title to display in view.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="destroyButton">Text for the ok button.</param>
+    /// <param name="otherButtons">Text for other buttons.</param>
+    /// <returns>Text for the pressed button</returns>
+    Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, params string[] otherButtons);
 
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <param name="title">Title to display in view.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="destroyButton">Text for the ok button.</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <param name="otherButtons">Text for other buttons.</param>
-        /// <returns>Text for the pressed button</returns>
-        Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons);
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <param name="title">Title to display in view.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="destroyButton">Text for the ok button.</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <param name="otherButtons">Text for other buttons.</param>
+    /// <returns>Text for the pressed button</returns>
+    Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons);
 
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <para>
-        /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
-        /// the callback action will be executed.
-        /// </para>
-        /// <param name="title">Text to display in action sheet</param>
-        /// <param name="buttons">Buttons displayed in action sheet</param>
-        /// <returns></returns>
-        Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons);
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <para>
+    /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
+    /// the callback action will be executed.
+    /// </para>
+    /// <param name="title">Text to display in action sheet</param>
+    /// <param name="buttons">Buttons displayed in action sheet</param>
+    /// <returns></returns>
+    Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons);
 
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <para>
-        /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
-        /// the callback action will be executed.
-        /// </para>
-        /// <param name="title">Text to display in action sheet</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <param name="buttons">Buttons displayed in action sheet</param>
-        /// <returns></returns>
-        Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons);
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <para>
+    /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
+    /// the callback action will be executed.
+    /// </para>
+    /// <param name="title">Text to display in action sheet</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <param name="buttons">Buttons displayed in action sheet</param>
+    /// <returns></returns>
+    Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons);
 
-        /// <summary>
-        /// Displays a native platform prompt, allowing the application user to enter a string.
-        /// </summary>
-        /// <param name="title">Title to display</param>
-        /// <param name="message">Message to display</param>
-        /// <param name="accept">Text for the accept button</param>
-        /// <param name="cancel">Text for the cancel button</param>
-        /// <param name="placeholder">Placeholder text to display in the prompt</param>
-        /// <param name="maxLength">Maximum length of the user response</param>
-        /// <param name="keyboardType">Keyboard type to use for the user response</param>
-        /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
-        /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
-        Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, KeyboardType keyboardType = KeyboardType.Default, string initialValue = "");
-    }
+    /// <summary>
+    /// Displays a native platform prompt, allowing the application user to enter a string.
+    /// </summary>
+    /// <param name="title">Title to display</param>
+    /// <param name="message">Message to display</param>
+    /// <param name="accept">Text for the accept button</param>
+    /// <param name="cancel">Text for the cancel button</param>
+    /// <param name="placeholder">Placeholder text to display in the prompt</param>
+    /// <param name="maxLength">Maximum length of the user response</param>
+    /// <param name="keyboardType">Keyboard type to use for the user response</param>
+    /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
+    /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
+    Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, KeyboardType keyboardType = KeyboardType.Default, string initialValue = "");
 }

--- a/src/Prism.Maui/Services/PageDialogs/PageDialogService.cs
+++ b/src/Prism.Maui/Services/PageDialogs/PageDialogService.cs
@@ -1,198 +1,195 @@
-﻿using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Prism.AppModel;
+﻿using Prism.AppModel;
 using FlowDirection = Prism.AppModel.FlowDirection;
 using MauiFlow = Microsoft.Maui.FlowDirection;
 
-namespace Prism.Services
+namespace Prism.Services;
+
+/// <summary>
+/// Implementation of the <see cref="IPageDialogService"/>
+/// </summary>
+public class PageDialogService : IPageDialogService
 {
+    private IApplication _application { get; }
+
     /// <summary>
-    /// Implementation of the <see cref="IPageDialogService"/>
+    /// Gets the <see cref="IWindow"/>.
     /// </summary>
-    public class PageDialogService : IPageDialogService
+    protected IWindow _window => _application.Windows[0];
+
+    /// <summary>
+    /// Gets the <see cref="IKeyboardMapper"/>.
+    /// </summary>
+    protected IKeyboardMapper _keyboardMapper { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="IPageDialogService"/>
+    /// </summary>
+    /// <param name="application">The <see cref="IApplication"/>.</param>
+    /// <param name="keyboardMapper">The <see cref="IKeyboardMapper"/>.</param>
+    public PageDialogService(IApplication application, IKeyboardMapper keyboardMapper)
     {
-        private IApplication _application { get; }
+        _application = application;
+        _keyboardMapper = keyboardMapper;
+    }
 
-        /// <summary>
-        /// Gets the <see cref="IWindow"/>.
-        /// </summary>
-        protected IWindow _window => _application.Windows[0];
+    /// <summary>
+    /// Presents an alert dialog to the application user with an accept and a cancel button.
+    /// </summary>
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="acceptButton">Text for the accept button.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
+    public virtual Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton)
+    {
+        return DisplayAlertAsync(title, message, acceptButton, cancelButton, FlowDirection.MatchParent);
+    }
 
-        /// <summary>
-        /// Gets the <see cref="IKeyboardMapper"/>.
-        /// </summary>
-        protected IKeyboardMapper _keyboardMapper { get; }
+    /// <summary>
+    /// Presents an alert dialog to the application user with an accept and a cancel button.
+    /// </summary>
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="acceptButton">Text for the accept button.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
+    public virtual Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection)
+    {
+        return GetMainPage().DisplayAlert(title, message, acceptButton, cancelButton, (MauiFlow)flowDirection);
+    }
 
-        /// <summary>
-        /// Creates a new <see cref="IPageDialogService"/>
-        /// </summary>
-        /// <param name="application">The <see cref="IApplication"/>.</param>
-        /// <param name="keyboardMapper">The <see cref="IKeyboardMapper"/>.</param>
-        public PageDialogService(IApplication application, IKeyboardMapper keyboardMapper)
+    /// <summary>
+    /// Presents an alert dialog to the application user with a single cancel button.
+    /// </summary>
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <returns></returns>
+    public virtual Task DisplayAlertAsync(string title, string message, string cancelButton)
+    {
+        return GetMainPage().DisplayAlert(title, message, cancelButton);
+    }
+
+    /// <summary>
+    /// Presents an alert dialog to the application user with a single cancel button.
+    /// </summary>
+    /// <para>
+    /// The <paramref name="message"/> can be empty.
+    /// </para>
+    /// <param name="title">Title to display.</param>
+    /// <param name="message">Message to display.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <returns></returns>
+    public virtual Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection)
+    {
+        return GetMainPage().DisplayAlert(title, message, cancelButton, (MauiFlow)flowDirection);
+    }
+
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <param name="title">Title to display in view.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="destroyButton">Text for the ok button.</param>
+    /// <param name="otherButtons">Text for other buttons.</param>
+    /// <returns>Text for the pressed button</returns>
+    public virtual Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, params string[] otherButtons)
+    {
+        return DisplayActionSheetAsync(title, cancelButton, destroyButton, FlowDirection.MatchParent, otherButtons);
+    }
+
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <param name="title">Title to display in view.</param>
+    /// <param name="cancelButton">Text for the cancel button.</param>
+    /// <param name="destroyButton">Text for the ok button.</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <param name="otherButtons">Text for other buttons.</param>
+    /// <returns>Text for the pressed button</returns>
+    public virtual Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons)
+    {
+        return GetMainPage().DisplayActionSheet(title, cancelButton, destroyButton, (MauiFlow)flowDirection, otherButtons);
+    }
+
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <para>
+    /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
+    /// the <see cref="System.Windows.Input.ICommand"/> or <see cref="Action"/> will be executed.
+    /// </para>
+    /// <param name="title">Text to display in action sheet</param>
+    /// <param name="buttons">Buttons displayed in action sheet</param>
+    /// <returns></returns>
+    public virtual async Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons)
+    {
+        await DisplayActionSheetAsync(title, FlowDirection.MatchParent, buttons);
+    }
+
+    /// <summary>
+    /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
+    /// </summary>
+    /// <para>
+    /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
+    /// the callback action will be executed.
+    /// </para>
+    /// <param name="title">Text to display in action sheet</param>
+    /// <param name="flowDirection">The Text flow direction.</param>
+    /// <param name="buttons">Buttons displayed in action sheet</param>
+    /// <returns></returns>
+    public virtual async Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons)
+    {
+        if (buttons == null || buttons.All(b => b == null))
+            throw new ArgumentException("At least one button needs to be supplied", nameof(buttons));
+
+        var destroyButton = buttons.FirstOrDefault(button => button != null && button.IsDestroy);
+        var cancelButton = buttons.FirstOrDefault(button => button != null && button.IsCancel);
+        var otherButtonsText = buttons.Where(button => button != null && !(button.IsDestroy || button.IsCancel)).Select(b => b.Text).ToArray();
+
+        var pressedButton = await DisplayActionSheetAsync(title, cancelButton?.Text, destroyButton?.Text, flowDirection, otherButtonsText);
+
+        foreach (var button in buttons.Where(button => button != null && button.Text.Equals(pressedButton)))
         {
-            _application = application;
-            _keyboardMapper = keyboardMapper;
+            await button.PressButton();
+            return;
         }
+    }
 
-        /// <summary>
-        /// Presents an alert dialog to the application user with an accept and a cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="acceptButton">Text for the accept button.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
-        public virtual Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton)
-        {
-            return DisplayAlertAsync(title, message, acceptButton, cancelButton, FlowDirection.MatchParent);
-        }
+    /// <summary>
+    /// Displays a native platform prompt, allowing the application user to enter a string.
+    /// </summary>
+    /// <param name="title">Title to display</param>
+    /// <param name="message">Message to display</param>
+    /// <param name="accept">Text for the accept button</param>
+    /// <param name="cancel">Text for the cancel button</param>
+    /// <param name="placeholder">Placeholder text to display in the prompt</param>
+    /// <param name="maxLength">Maximum length of the user response</param>
+    /// <param name="keyboardType">Keyboard type to use for the user response</param>
+    /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
+    /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
+    public virtual Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, KeyboardType keyboardType = KeyboardType.Default, string initialValue = "")
+    {
+        var keyboard = _keyboardMapper.Map(keyboardType);
+        return GetMainPage().DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);
+    }
 
-        /// <summary>
-        /// Presents an alert dialog to the application user with an accept and a cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="acceptButton">Text for the accept button.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <returns><c>true</c> if non-destructive button pressed; otherwise <c>false</c>/></returns>
-        public virtual Task<bool> DisplayAlertAsync(string title, string message, string acceptButton, string cancelButton, FlowDirection flowDirection)
-        {
-            return GetMainPage().DisplayAlert(title, message, acceptButton, cancelButton, (MauiFlow)flowDirection);
-        }
+    protected Page GetMainPage()
+    {
+        if (_window.Content is Page page)
+            return page;
 
-        /// <summary>
-        /// Presents an alert dialog to the application user with a single cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <returns></returns>
-        public virtual Task DisplayAlertAsync(string title, string message, string cancelButton)
-        {
-            return GetMainPage().DisplayAlert(title, message, cancelButton);
-        }
-
-        /// <summary>
-        /// Presents an alert dialog to the application user with a single cancel button.
-        /// </summary>
-        /// <para>
-        /// The <paramref name="message"/> can be empty.
-        /// </para>
-        /// <param name="title">Title to display.</param>
-        /// <param name="message">Message to display.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <returns></returns>
-        public virtual Task DisplayAlertAsync(string title, string message, string cancelButton, FlowDirection flowDirection)
-        {
-            return GetMainPage().DisplayAlert(title, message, cancelButton, (MauiFlow)flowDirection);
-        }
-
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <param name="title">Title to display in view.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="destroyButton">Text for the ok button.</param>
-        /// <param name="otherButtons">Text for other buttons.</param>
-        /// <returns>Text for the pressed button</returns>
-        public virtual Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, params string[] otherButtons)
-        {
-            return DisplayActionSheetAsync(title, cancelButton, destroyButton, FlowDirection.MatchParent, otherButtons);
-        }
-
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <param name="title">Title to display in view.</param>
-        /// <param name="cancelButton">Text for the cancel button.</param>
-        /// <param name="destroyButton">Text for the ok button.</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <param name="otherButtons">Text for other buttons.</param>
-        /// <returns>Text for the pressed button</returns>
-        public virtual Task<string> DisplayActionSheetAsync(string title, string cancelButton, string destroyButton, FlowDirection flowDirection, params string[] otherButtons)
-        {
-            return GetMainPage().DisplayActionSheet(title, cancelButton, destroyButton, (MauiFlow)flowDirection, otherButtons);
-        }
-
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <para>
-        /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
-        /// the <see cref="System.Windows.Input.ICommand"/> or <see cref="Action"/> will be executed.
-        /// </para>
-        /// <param name="title">Text to display in action sheet</param>
-        /// <param name="buttons">Buttons displayed in action sheet</param>
-        /// <returns></returns>
-        public virtual async Task DisplayActionSheetAsync(string title, params IActionSheetButton[] buttons)
-        {
-            await DisplayActionSheetAsync(title, FlowDirection.MatchParent, buttons);
-        }
-
-        /// <summary>
-        /// Displays a native platform action sheet, allowing the application user to choose from several buttons.
-        /// </summary>
-        /// <para>
-        /// The text displayed in the action sheet will be the value for <see cref="IActionSheetButton.Text"/> and when pressed
-        /// the callback action will be executed.
-        /// </para>
-        /// <param name="title">Text to display in action sheet</param>
-        /// <param name="flowDirection">The Text flow direction.</param>
-        /// <param name="buttons">Buttons displayed in action sheet</param>
-        /// <returns></returns>
-        public virtual async Task DisplayActionSheetAsync(string title, FlowDirection flowDirection, params IActionSheetButton[] buttons)
-        {
-            if (buttons == null || buttons.All(b => b == null))
-                throw new ArgumentException("At least one button needs to be supplied", nameof(buttons));
-
-            var destroyButton = buttons.FirstOrDefault(button => button != null && button.IsDestroy);
-            var cancelButton = buttons.FirstOrDefault(button => button != null && button.IsCancel);
-            var otherButtonsText = buttons.Where(button => button != null && !(button.IsDestroy || button.IsCancel)).Select(b => b.Text).ToArray();
-
-            var pressedButton = await DisplayActionSheetAsync(title, cancelButton?.Text, destroyButton?.Text, flowDirection, otherButtonsText);
-
-            foreach (var button in buttons.Where(button => button != null && button.Text.Equals(pressedButton)))
-            {
-                await button.PressButton();
-                return;
-            }
-        }
-
-        /// <summary>
-        /// Displays a native platform prompt, allowing the application user to enter a string.
-        /// </summary>
-        /// <param name="title">Title to display</param>
-        /// <param name="message">Message to display</param>
-        /// <param name="accept">Text for the accept button</param>
-        /// <param name="cancel">Text for the cancel button</param>
-        /// <param name="placeholder">Placeholder text to display in the prompt</param>
-        /// <param name="maxLength">Maximum length of the user response</param>
-        /// <param name="keyboardType">Keyboard type to use for the user response</param>
-        /// <param name="initialValue">Pre-defined response that will be displayed, and which can be edited</param>
-        /// <returns><c>string</c> entered by the user. <c>null</c> if cancel is pressed</returns>
-        public virtual Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = default, int maxLength = -1, KeyboardType keyboardType = KeyboardType.Default, string initialValue = "")
-        {
-            var keyboard = _keyboardMapper.Map(keyboardType);
-            return GetMainPage().DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);
-        }
-
-        protected Page GetMainPage()
-        {
-            if (_window.Content is Page page)
-                return page;
-
-            throw new NullReferenceException("The Application Window View has not been set or has been set to something other than a Page.");
-        }
+        throw new NullReferenceException("The Application Window View has not been set or has been set to something other than a Page.");
     }
 }


### PR DESCRIPTION
# Description

Fluent builders can be extremely helpful and on top of Prism's URI navigation. This unlocks a lot of possibilities for dynamically building a URI from adding query parameters to individual segments, to ViewModel first navigation. The Builders are finalized with a Navigate call which can be easily used whether or not you're in an async method. The overloads additionally make it easy to invoke callback logic OnSuccess or OnError.

```cs
// Shown with option OnError callback
navigationService.CreateBuilder()
                .AddNavigationSegment("MainPage")
                .AddNavigationPage()
                .AddNavigationSegment<ViewAViewModel>()
                .AddNavigationSegment("ViewB")
                .Navigate(HandleNavigationError);

// This returns the INavigationResult... 
// Also available with overloads to provide OnSuccess & OnError callbacks
navigationService.CreateBuilder()
                .AddTabbedSegment(b =>
                {
                    b.CreateTab(t => t.AddNavigationSegment<ViewAViewModel>())
                     .CreateTab("ViewB")
                     .CreateTab(t => t.AddNavigationPage().AddNavigationSegment<ViewCViewModel>())
                     .SelectTab<ViewBViewModel>();
                })
                .NavigateAsync();
```

