### PR TITLE
Global Navigation Observer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,9 +16,11 @@
     <PrismLicenseFile>$(MSBuildThisFileDirectory)LICENSE</PrismLicenseFile>
     <PackageTags>prism;maui;dotnet-maui;xaml;mvvm;ios;android;mac;winui</PackageTags>
     <Copyright>Copyright Dan Siegel 2021</Copyright>
-    <Description>This is a special preview package. In order to use this be sure that you have installed the Maui workload with Visual Studio 2022 preview 4 or later. Alternatively you may use Maui-Check to ensure that your environment has the required prerequesites to build from the command line with Visual Studio Code.
+    <Description>
+      Prism is a fully open source version of the Prism guidance originally produced by Microsoft Patterns &amp; Practices. Prism provides an implementation of a collection of design patterns that are helpful in writing well structured, maintainable, and testable XAML applications, including MVVM, dependency injection, commanding, event aggregation, and more. Prism's core functionality is a shared library targeting the .NET Framework and .NET Standard. Features that need to be platform specific are implemented in the respective libraries for the target platform (WPF, Uno Platform, Xamarin Forms, and .NET MAUI).
 
-As this is special preview build there are no docs, be sure to check out the source repo at: https://github.com/dansiegel/prism.maui </Description>
+      Prism for .NET MAUI helps you more easily design and build rich, flexible, and easy to maintain .NET MAUI applications. This library provides user interface composition as well as modularity support.
+    </Description>
 <!-- HACK: WinUI seems to have issues without this -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
@@ -38,7 +40,7 @@ As this is special preview build there are no docs, be sure to check out the sou
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" 
-                      Version="3.5.104"
+                      Version="3.5.107"
                       PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub"
                       Version="1.1.1"

--- a/Prism.Maui.sln
+++ b/Prism.Maui.sln
@@ -9,7 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6CAB3327-8C0
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.DryIoc.Maui", "src\Prism.DryIoc.Maui\Prism.DryIoc.Maui.csproj", "{6C5C1F1F-DA92-4307-862F-5034BF8B0858}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Prism.Maui", "src\Prism.Maui\Prism.Maui.csproj", "{6171FE41-1F11-4CFA-8FD8-8222B97C7C63}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.Maui", "src\Prism.Maui\Prism.Maui.csproj", "{6171FE41-1F11-4CFA-8FD8-8222B97C7C63}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Prism.DryIoc.Shared", "src\Prism.DryIoc.Shared\Prism.DryIoc.Shared.shproj", "{6E7EC81D-DA39-4C4F-A898-0148558C34F4}"
 EndProject
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiModule", "sample\MauiModule\MauiModule.csproj", "{EB8CD219-0CA7-4AE3-A7B7-6D883400CCE0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prism.Maui.Rx", "src\Prism.Maui.Rx\Prism.Maui.Rx.csproj", "{D364B3F0-2D41-4EF8-BE1D-D83825322F61}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -127,6 +129,22 @@ Global
 		{EB8CD219-0CA7-4AE3-A7B7-6D883400CCE0}.Release|x64.Build.0 = Release|Any CPU
 		{EB8CD219-0CA7-4AE3-A7B7-6D883400CCE0}.Release|x86.ActiveCfg = Release|Any CPU
 		{EB8CD219-0CA7-4AE3-A7B7-6D883400CCE0}.Release|x86.Build.0 = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|arm64.Build.0 = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|x64.Build.0 = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Debug|x86.Build.0 = Debug|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|arm64.ActiveCfg = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|arm64.Build.0 = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|x64.ActiveCfg = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|x64.Build.0 = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|x86.ActiveCfg = Release|Any CPU
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,6 +156,7 @@ Global
 		{3BFAB205-050B-47B7-9AB8-BE799E07DA90} = {7CB47440-CCBC-4E16-B2B9-9FD472154117}
 		{16AEEF3D-B119-4EE0-9B1F-B9E0FDF0EEAB} = {06F06128-578F-449D-B3D6-D04A531B1018}
 		{EB8CD219-0CA7-4AE3-A7B7-6D883400CCE0} = {06F06128-578F-449D-B3D6-D04A531B1018}
+		{D364B3F0-2D41-4EF8-BE1D-D83825322F61} = {6CAB3327-8C0A-4D0B-BF18-CEFD15B84BA7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7E696A15-8B47-4BC2-8997-071E61157406}

--- a/sample/PrismMauiDemo/MauiProgram.cs
+++ b/sample/PrismMauiDemo/MauiProgram.cs
@@ -16,10 +16,21 @@ public static class MauiProgram
             })
             .RegisterTypes(containerRegistry =>
             {
+                containerRegistry.RegisterGlobalNavigationObserver();
                 containerRegistry.RegisterForNavigation<MainPage>();
                 containerRegistry.RegisterForNavigation<RootPage>();
                 containerRegistry.RegisterForNavigation<SamplePage>();
             })
+            .AddGlobalNavigationObserver(context => context.Subscribe(x =>
+            {
+                if (x.Type == NavigationRequestType.Navigate)
+                    Console.WriteLine($"Navigation: {x.Type} - {x.Uri}");
+                else
+                    Console.WriteLine($"Navigation: {x.Type}");
+
+                var status = x.Cancelled ? "Cancelled" : x.Result.Success ? "Success" : "Failed";
+                Console.WriteLine($"Result: {status}");
+            }))
             .OnAppStart(navigationService => navigationService.CreateBuilder()
                 .AddNavigationSegment("MainPage")
                 .AddNavigationPage()

--- a/sample/PrismMauiDemo/PrismMauiDemo.csproj
+++ b/sample/PrismMauiDemo/PrismMauiDemo.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Prism.DryIoc.Maui\Prism.DryIoc.Maui.csproj" />
+    <ProjectReference Include="..\..\src\Prism.Maui.Rx\Prism.Maui.Rx.csproj" />
     <ProjectReference Include="..\..\src\Prism.Maui\Prism.Maui.csproj" />
     <ProjectReference Include="..\MauiModule\MauiModule.csproj" />
   </ItemGroup>

--- a/src/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
+++ b/src/Prism.DryIoc.Maui/Prism.DryIoc.Maui.csproj
@@ -5,6 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>
     <ImplicitUsings>true</ImplicitUsings>
+    <Description>Prism.DryIoc.Maui provides the implementation of Prism's IContainerExtension using the DryIoc container. This is currently the only supported container for .NET MAUI.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Prism.Maui.Rx/GlobalNavigationObserver.cs
+++ b/src/Prism.Maui.Rx/GlobalNavigationObserver.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reactive.Subjects;
+using Prism.Events;
+
+namespace Prism.Navigation;
+
+internal class GlobalNavigationObserver : IGlobalNavigationObserver, IDisposable
+{
+    private readonly Subject<NavigationRequestContext> _subject;
+    private SubscriptionToken _token;
+
+    public GlobalNavigationObserver(IEventAggregator eventAggregator)
+    {
+        _subject = new Subject<NavigationRequestContext>();
+        _token = eventAggregator.GetEvent<NavigationRequestEvent>().Subscribe(context => _subject.OnNext(context));
+    }
+
+    public IObservable<NavigationRequestContext> NavigationRequest => _subject;
+
+    public void Dispose()
+    {
+        if (_token is null)
+            return;
+
+        _token.Dispose();
+        _token = null;
+        _subject.Dispose();
+    }
+}

--- a/src/Prism.Maui.Rx/IGlobalNavigationObserver.cs
+++ b/src/Prism.Maui.Rx/IGlobalNavigationObserver.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Prism.Navigation;
+
+public interface IGlobalNavigationObserver
+{
+    IObservable<NavigationRequestContext> NavigationRequest { get; }
+}

--- a/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
+++ b/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Ioc;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Prism.Ioc;
 
 namespace Prism.Navigation;
 
@@ -14,4 +15,19 @@ public static class NavigationObserverRegistrationExtensions
         s_IsRegistered = true;
         return container.RegisterSingleton<IGlobalNavigationObserver, GlobalNavigationObserver>();
     }
+
+    public static IServiceCollection RegisterGlobalNavigationObserver(this IServiceCollection services)
+    {
+        if (s_IsRegistered)
+            return services;
+
+        s_IsRegistered = true;
+        return services.AddSingleton<IGlobalNavigationObserver, GlobalNavigationObserver>();
+    }
+
+    public static PrismAppBuilder AddGlobalNavigationObserver(this PrismAppBuilder builder, Action<IObservable<NavigationRequestContext>> addObservable) =>
+        builder.OnInitialized(c => addObservable(c.Resolve<IGlobalNavigationObserver>().NavigationRequest));
+
+    public static PrismAppBuilder AddGlobalNavigationObserver(this PrismAppBuilder builder, Action<IContainerProvider, IObservable<NavigationRequestContext>> addObservable) =>
+        builder.OnInitialized(c => addObservable(c, c.Resolve<IGlobalNavigationObserver>().NavigationRequest));
 }

--- a/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
+++ b/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Prism.Ioc;
+
+namespace Prism.Navigation;
+
+public static class NavigationObserverRegistrationExtensions
+{
+    private static bool s_IsRegistered;
+
+    public static IContainerRegistry RegisterGlobalNavigationObserver(this IContainerRegistry container)
+    {
+        if (s_IsRegistered)
+            return container;
+
+        s_IsRegistered = true;
+        return container.RegisterSingleton<IGlobalNavigationObserver, GlobalNavigationObserver>();
+    }
+}

--- a/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
+++ b/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
@@ -26,8 +26,20 @@ public static class NavigationObserverRegistrationExtensions
     }
 
     public static PrismAppBuilder AddGlobalNavigationObserver(this PrismAppBuilder builder, Action<IObservable<NavigationRequestContext>> addObservable) =>
-        builder.OnInitialized(c => addObservable(c.Resolve<IGlobalNavigationObserver>().NavigationRequest));
+        builder.OnInitialized(c =>
+        {
+            if (!s_IsRegistered)
+                throw new Exception("IGlobalNavigationObserver has not been registered. Be sure to call 'container.RegisterGlobalNavigationObserver()'.");
+
+            addObservable(c.Resolve<IGlobalNavigationObserver>().NavigationRequest);
+        });
 
     public static PrismAppBuilder AddGlobalNavigationObserver(this PrismAppBuilder builder, Action<IContainerProvider, IObservable<NavigationRequestContext>> addObservable) =>
-        builder.OnInitialized(c => addObservable(c, c.Resolve<IGlobalNavigationObserver>().NavigationRequest));
+        builder.OnInitialized(c =>
+        {
+            if (!s_IsRegistered)
+                throw new Exception("IGlobalNavigationObserver has not been registered. Be sure to call 'container.RegisterGlobalNavigationObserver()'.");
+
+            addObservable(c, c.Resolve<IGlobalNavigationObserver>().NavigationRequest);
+        });
 }

--- a/src/Prism.Maui.Rx/Prism.Maui.Rx.csproj
+++ b/src/Prism.Maui.Rx/Prism.Maui.Rx.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>true</ImplicitUsings>
+    <Description>Prism.Maui.Rx is a support package for .NET MAUI developers. This package provides some helpers to access an IObservable for globally handling Navigation Request Results.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Prism.Maui.Rx/Prism.Maui.Rx.csproj
+++ b/src/Prism.Maui.Rx/Prism.Maui.Rx.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Prism.Maui\Prism.Maui.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Prism.Maui/Behaviors/NavigationPageSystemGoBackBehavior.cs
+++ b/src/Prism.Maui/Behaviors/NavigationPageSystemGoBackBehavior.cs
@@ -21,6 +21,7 @@ public class NavigationPageSystemGoBackBehavior : BehaviorBase<NavigationPage>
     {
         if (PageNavigationService.NavigationSource == PageNavigationSource.Device)
         {
+            System.Diagnostics.Trace.WriteLine("NavigationPage has encountered an unhandled GoBack. Be sure to inherit from PrismNavigationPage.");
             PageUtilities.HandleSystemGoBack(e.Page, AssociatedObject.CurrentPage);
         }
     }

--- a/src/Prism.Maui/Common/PageUtilities.cs
+++ b/src/Prism.Maui/Common/PageUtilities.cs
@@ -229,19 +229,8 @@ public static class PageUtilities
 
     public static async Task HandleNavigationPageGoBack(NavigationPage navigationPage)
     {
-        var previousPage = navigationPage.CurrentPage;
-        var parameters = new NavigationParameters();
-        parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
-        if (!CanNavigate(previousPage, parameters) ||
-            !await CanNavigateAsync(previousPage, parameters))
-            return;
-
-        PageNavigationService.NavigationSource = PageNavigationSource.NavigationService;
-        await navigationPage.PopAsync();
-        PageNavigationService.NavigationSource = PageNavigationSource.Device;
-        OnNavigatedFrom(previousPage, parameters);
-        OnNavigatedTo(navigationPage.CurrentPage, parameters);
-        DestroyPage(previousPage);
+        var navigationService = Navigation.Xaml.Navigation.GetNavigationService(navigationPage);
+        await navigationService.GoBackAsync();
     }
 
     public static void HandleSystemGoBack(IView previousPage, IView currentPage)

--- a/src/Prism.Maui/Common/PageUtilities.cs
+++ b/src/Prism.Maui/Common/PageUtilities.cs
@@ -229,7 +229,7 @@ public static class PageUtilities
 
     public static async Task HandleNavigationPageGoBack(NavigationPage navigationPage)
     {
-        var navigationService = Navigation.Xaml.Navigation.GetNavigationService(navigationPage);
+        var navigationService = Navigation.Xaml.Navigation.GetNavigationService(navigationPage.CurrentPage);
         await navigationService.GoBackAsync();
     }
 

--- a/src/Prism.Maui/Events/NavigationPubSubEvent.cs
+++ b/src/Prism.Maui/Events/NavigationPubSubEvent.cs
@@ -1,8 +1,0 @@
-﻿using Prism.Navigation;
-
-namespace Prism.Events;
-
-public class NavigationPubSubEvent : PubSubEvent<NavigationRequestContext>
-{
-}
-

--- a/src/Prism.Maui/Events/NavigationPubSubEvent.cs
+++ b/src/Prism.Maui/Events/NavigationPubSubEvent.cs
@@ -1,0 +1,8 @@
+﻿using Prism.Navigation;
+
+namespace Prism.Events;
+
+public class NavigationPubSubEvent : PubSubEvent<NavigationRequestContext>
+{
+}
+

--- a/src/Prism.Maui/Events/NavigationRequestEvent.cs
+++ b/src/Prism.Maui/Events/NavigationRequestEvent.cs
@@ -1,0 +1,8 @@
+﻿using Prism.Navigation;
+
+namespace Prism.Events;
+
+public class NavigationRequestEvent : PubSubEvent<NavigationRequestContext>
+{
+}
+

--- a/src/Prism.Maui/Navigation/KnownNavigationParameters.cs
+++ b/src/Prism.Maui/Navigation/KnownNavigationParameters.cs
@@ -18,6 +18,11 @@ public static class KnownNavigationParameters
     public const string UseModalNavigation = "useModalNavigation";
 
     /// <summary>
+    /// Used to control whether the navigation should be animated.
+    /// </summary>
+    public const string Animated = "animated";
+
+    /// <summary>
     /// Used to define a navigation parameter that is bound directly to a CommandParameter via <code>{Binding .}</code>.
     /// </summary>
     public const string XamlParam = "xamlParam";

--- a/src/Prism.Maui/Navigation/NavigationRequestContext.cs
+++ b/src/Prism.Maui/Navigation/NavigationRequestContext.cs
@@ -1,0 +1,10 @@
+﻿namespace Prism.Navigation;
+
+public record NavigationRequestContext
+{
+    public bool Cancelled => Result?.Exception is not null && Result.Exception is NavigationException ne && ne.Message == NavigationException.IConfirmNavigationReturnedFalse;
+    public NavigationRequestType Type { get; init; }
+    public Uri? Uri { get; init; }
+    public INavigationParameters Parameters { get; init; }
+    public INavigationResult Result { get; init; }
+}

--- a/src/Prism.Maui/Navigation/NavigationRequestType.cs
+++ b/src/Prism.Maui/Navigation/NavigationRequestType.cs
@@ -1,0 +1,8 @@
+﻿namespace Prism.Navigation;
+
+public enum NavigationRequestType
+{
+    Navigate,
+    GoBack,
+    GoToRoot,
+}

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -1,5 +1,6 @@
 using Prism.Behaviors;
 using Prism.Common;
+using Prism.Events;
 using Prism.Ioc;
 using Application = Microsoft.Maui.Controls.Application;
 
@@ -19,6 +20,7 @@ public class PageNavigationService : INavigationService, IPageAware
 
     private readonly IContainerProvider _container;
     protected readonly IApplication _application;
+    protected readonly IEventAggregator _eventAggregator;
     protected Window Window;
 
     protected Page _page;
@@ -48,10 +50,11 @@ public class PageNavigationService : INavigationService, IPageAware
     /// <param name="container">The <see cref="IContainerProvider"/> that will be used to resolve pages for navigation.</param>
     /// <param name="application">The <see cref="IApplication"/> that will let us ensure the Application.MainPage is set.</param>
     /// <param name="pageBehaviorFactory">The <see cref="IPageBehaviorFactory"/> that will apply base and custom behaviors to pages created in the <see cref="PageNavigationService"/>.</param>
-    public PageNavigationService(IContainerProvider container, IApplication application)
+    public PageNavigationService(IContainerProvider container, IApplication application, IEventAggregator eventAggregator)
     {
         _container = container;
         _application = application;
+        _eventAggregator = eventAggregator;
     }
 
     /// <summary>

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -60,42 +60,9 @@ public class PageNavigationService : INavigationService, IPageAware
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
-    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-    public virtual Task<INavigationResult> GoBackAsync()
-    {
-        return GoBackAsync(null);
-    }
-
-    /// <summary>
-    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-    /// </summary>
     /// <param name="parameters">The navigation parameters</param>
     /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-    public virtual Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
-    {
-        return GoBackInternal(parameters, null, true);
-    }
-
-    /// <summary>
-    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-    /// </summary>
-    /// <param name="parameters">The navigation parameters</param>
-    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
-    public virtual Task<INavigationResult> GoBackAsync(INavigationParameters parameters, bool? useModalNavigation, bool animated)
-    {
-        return GoBackInternal(parameters, useModalNavigation, animated);
-    }
-
-    /// <summary>
-    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
-    /// </summary>
-    /// <param name="parameters">The navigation parameters</param>
-    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
-    protected async virtual Task<INavigationResult> GoBackInternal(INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    public virtual async Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
     {
         Page page = null;
         try
@@ -195,17 +162,7 @@ public class PageNavigationService : INavigationService, IPageAware
     /// <param name="parameters">The navigation parameters</param>
     /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
     /// <remarks>Only works when called from a View within a NavigationPage</remarks>
-    public virtual Task<INavigationResult> GoBackToRootAsync(INavigationParameters parameters)
-    {
-        return GoBackToRootInternal(parameters);
-    }
-
-    /// <summary>
-    /// When navigating inside a NavigationPage: Pops all but the root Page off the navigation stack
-    /// </summary>
-    /// <param name="parameters">The navigation parameters</param>
-    /// <remarks>Only works when called from a View within a NavigationPage</remarks>
-    protected async virtual Task<INavigationResult> GoBackToRootInternal(INavigationParameters parameters)
+    public virtual async Task<INavigationResult> GoBackToRootAsync(INavigationParameters parameters)
     {
         try
         {

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -49,7 +49,7 @@ public class PageNavigationService : INavigationService, IPageAware
     /// </summary>
     /// <param name="container">The <see cref="IContainerProvider"/> that will be used to resolve pages for navigation.</param>
     /// <param name="application">The <see cref="IApplication"/> that will let us ensure the Application.MainPage is set.</param>
-    /// <param name="pageBehaviorFactory">The <see cref="IPageBehaviorFactory"/> that will apply base and custom behaviors to pages created in the <see cref="PageNavigationService"/>.</param>
+    /// <param name="eventAggregator">The <see cref="IEventAggregator"/> that will raise <see cref="NavigationRequestEvent"/>.</param>
     public PageNavigationService(IContainerProvider container, IApplication application, IEventAggregator eventAggregator)
     {
         _container = container;
@@ -212,23 +212,6 @@ public class PageNavigationService : INavigationService, IPageAware
     }
 
     /// <summary>
-    /// Initiates navigation to the target specified by the <paramref name="name"/>.
-    /// </summary>
-    /// <param name="name">The name of the target to navigate to.</param>
-    /// <param name="parameters">The navigation parameters</param>
-    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-    protected virtual Task<INavigationResult> NavigateInternal(string name, INavigationParameters parameters, bool? useModalNavigation, bool animated)
-    {
-        if (name.StartsWith(RemovePageRelativePath))
-        {
-            name = name.Replace(RemovePageRelativePath, RemovePageInstruction);
-        }
-
-        return NavigateInternal(UriParsingHelper.Parse(name), parameters, useModalNavigation, animated);
-    }
-
-    /// <summary>
     /// Initiates navigation to the target specified by the <paramref name="uri"/>.
     /// </summary>
     /// <param name="uri">The Uri to navigate to</param>
@@ -237,23 +220,7 @@ public class PageNavigationService : INavigationService, IPageAware
     /// <example>
     /// NavigateAsync(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
     /// </example>
-    public virtual Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters)
-    {
-        return NavigateInternal(uri, parameters, null, true);
-    }
-
-    /// <summary>
-    /// Initiates navigation to the target specified by the <paramref name="uri"/>.
-    /// </summary>
-    /// <param name="uri">The Uri to navigate to</param>
-    /// <param name="parameters">The navigation parameters</param>
-    /// <param name="useModalNavigation">If <c>true</c> uses PopModalAsync, if <c>false</c> uses PopAsync</param>
-    /// <param name="animated">If <c>true</c> the transition is animated, if <c>false</c> there is no animation on transition.</param>
-    /// <remarks>Navigation parameters can be provided in the Uri and by using the <paramref name="parameters"/>.</remarks>
-    /// <example>
-    /// Navigate(new Uri("MainPage?id=3&amp;name=brian", UriKind.RelativeSource), parameters);
-    /// </example>
-    protected async virtual Task<INavigationResult> NavigateInternal(Uri uri, INavigationParameters parameters, bool? useModalNavigation, bool animated)
+    public virtual async Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters)
     {
         try
         {
@@ -266,12 +233,12 @@ public class PageNavigationService : INavigationService, IPageAware
 
             if (uri.IsAbsoluteUri)
             {
-                await ProcessNavigationForAbsoluteUri(navigationSegments, parameters, useModalNavigation, animated);
+                await ProcessNavigationForAbsoluteUri(navigationSegments, parameters, null, true);
                 return new NavigationResult { Success = true };
             }
             else
             {
-                await ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, useModalNavigation, animated);
+                await ProcessNavigation(GetCurrentPage(), navigationSegments, parameters, null, true);
                 return new NavigationResult { Success = true };
             }
         }
@@ -304,9 +271,9 @@ public class PageNavigationService : INavigationService, IPageAware
         var nextSegment = segments.Dequeue();
 
         var pageParameters = UriParsingHelper.GetSegmentParameters(nextSegment);
-        var useModalNavigation = pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation) ? pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation) : false;
+        //var useModalNavigation = pageParameters.ContainsKey(KnownNavigationParameters.UseModalNavigation) ? pageParameters.GetValue<bool>(KnownNavigationParameters.UseModalNavigation) : false;
 
-        var animated = pageParameters.ContainsKey(KnownNavigationParameters.Animated) ? pageParameters.GetValue<bool>(KnownNavigationParameters.Animated) : true;
+        //var animated = pageParameters.ContainsKey(KnownNavigationParameters.Animated) ? pageParameters.GetValue<bool>(KnownNavigationParameters.Animated) : true;
 
         if (nextSegment == RemovePageSegment)
         {

--- a/src/Prism.Maui/PrismApplication.cs
+++ b/src/Prism.Maui/PrismApplication.cs
@@ -20,6 +20,17 @@ public abstract class PrismApplication : Application, ILegacyPrismApplication
         _containerExtension = ContainerLocator.Current;
         RegisterTypes(_containerExtension);
         NavigationService = Container.Resolve<INavigationService>((typeof(IApplication), this));
+        this.ModalPopping += PrismApplication_ModalPopping;
+    }
+
+    private async void PrismApplication_ModalPopping(object sender, ModalPoppingEventArgs e)
+    {
+        if (PageNavigationService.NavigationSource == PageNavigationSource.NavigationService)
+            return;
+
+        e.Cancel = true;
+        var navService = Navigation.Xaml.Navigation.GetNavigationService(e.Modal);
+        await navService.GoBackAsync();
     }
 
     void ILegacyPrismApplication.OnInitialized() => OnInitialized();


### PR DESCRIPTION
# Description

Globally handling Navigation Requests has always been a challenge because the NavigationService can not operate as a Singleton and instead has to work as service Scoped to the Page. This PR introduces a NavigationRequestContext and PubSubEvent that is fired by the NavigationService any time a Navigation Method is executed. Prism.Maui manages to do this using the IEventAggregator, however a new Prism.Maui.Rx package has been added to expose some helpers that encapsulates this as an IObservable.

- Also fixes bug with the GoBack on a NavigationPage back button.