### PR TITLE
Prevent 2nd Navigation until first completes

### DIFF
--- a/sample/PrismMauiDemo/MauiProgram.cs
+++ b/sample/PrismMauiDemo/MauiProgram.cs
@@ -1,5 +1,6 @@
 ﻿using MauiModule;
 using MauiModule.ViewModels;
+using PrismMauiDemo.ViewModels;
 using PrismMauiDemo.Views;
 
 namespace PrismMauiDemo;
@@ -20,6 +21,7 @@ public static class MauiProgram
                 containerRegistry.RegisterForNavigation<MainPage>();
                 containerRegistry.RegisterForNavigation<RootPage>();
                 containerRegistry.RegisterForNavigation<SamplePage>();
+                containerRegistry.RegisterForNavigation<SplashPage>();
             })
             .AddGlobalNavigationObserver(context => context.Subscribe(x =>
             {
@@ -32,10 +34,7 @@ public static class MauiProgram
                 Console.WriteLine($"Result: {status}");
             }))
             .OnAppStart(navigationService => navigationService.CreateBuilder()
-                .AddNavigationSegment("MainPage")
-                .AddNavigationPage()
-                .AddNavigationSegment<ViewAViewModel>()
-                .AddNavigationSegment("ViewB")
+                .AddNavigationSegment<SplashPageViewModel>()
                 .Navigate(HandleNavigationError))
             //.OnAppStart(async navigationService =>
             //{

--- a/sample/PrismMauiDemo/ViewModels/SplashPageViewModel.cs
+++ b/sample/PrismMauiDemo/ViewModels/SplashPageViewModel.cs
@@ -1,0 +1,23 @@
+﻿namespace PrismMauiDemo.ViewModels;
+
+internal class SplashPageViewModel : IPageLifecycleAware
+{
+    private INavigationService _navigationService { get; }
+
+    public SplashPageViewModel(INavigationService navigationService)
+    {
+        _navigationService = navigationService;
+    }
+
+    public void OnAppearing()
+    {
+        _navigationService.CreateBuilder()
+            .AddNavigationSegment<RootPageViewModel>()
+            .Navigate();
+    }
+
+    public void OnDisappearing()
+    {
+
+    }
+}

--- a/sample/PrismMauiDemo/Views/SplashPage.xaml
+++ b/sample/PrismMauiDemo/Views/SplashPage.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="PrismMauiDemo.Views.SplashPage"
+             Title="Splash Page">
+  <StackLayout>
+    <Label Text="Loading..."
+           VerticalOptions="Center" 
+           HorizontalOptions="Center" />
+  </StackLayout>
+</ContentPage>

--- a/sample/PrismMauiDemo/Views/SplashPage.xaml.cs
+++ b/sample/PrismMauiDemo/Views/SplashPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace PrismMauiDemo.Views;
+
+public partial class SplashPage : ContentPage
+{
+    public SplashPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
+++ b/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using Prism.Navigation.Builder;
+﻿using Prism.Navigation.Builder;
 
 namespace Prism.Navigation;
 
@@ -27,24 +26,19 @@ public static class NavigationBuilderExtensions
                 o.UseModalNavigation(useModalNavigation.Value);
         });
 
-    public static ICreateTabBuilder AddNavigationSegment<TViewModel>(this ICreateTabBuilder builder)
-        where TViewModel : class, INotifyPropertyChanged =>
+    public static ICreateTabBuilder AddNavigationSegment<TViewModel>(this ICreateTabBuilder builder)  =>
         builder.AddNavigationSegment<TViewModel>(b => { });
 
-    public static ICreateTabBuilder AddNavigationSegment<TViewModel>(this ICreateTabBuilder builder, Action<ISegmentBuilder> configureSegment)
-        where TViewModel : class, INotifyPropertyChanged =>
+    public static ICreateTabBuilder AddNavigationSegment<TViewModel>(this ICreateTabBuilder builder, Action<ISegmentBuilder> configureSegment) =>
         builder.AddNavigationSegment(GetNavigationKey<TViewModel>(), configureSegment);
 
-    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder)
-        where TViewModel : class, INotifyPropertyChanged =>
+    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder) =>
         builder.AddNavigationSegment<TViewModel>(b => { });
 
-    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder, Action<ISegmentBuilder> configureSegment)
-        where TViewModel : class, INotifyPropertyChanged =>
+    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder, Action<ISegmentBuilder> configureSegment) =>
         builder.AddNavigationSegment(GetNavigationKey<TViewModel>(), configureSegment);
 
-    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder, bool useModalNavigation)
-        where TViewModel : class, INotifyPropertyChanged =>
+    public static INavigationBuilder AddNavigationSegment<TViewModel>(this INavigationBuilder builder, bool useModalNavigation) =>
         builder.AddNavigationSegment<TViewModel>(b => b.UseModalNavigation(useModalNavigation));
 
     // Will check for the Navigation key of a registered NavigationPage
@@ -125,14 +119,12 @@ public static class NavigationBuilderExtensions
         builder.CreateTab(o => o.AddNavigationSegment(segmentNameOrUri));
 
     public static ITabbedSegmentBuilder CreateTab<TViewModel>(this ITabbedSegmentBuilder builder)
-        where TViewModel : class, INotifyPropertyChanged
     {
         var navigationKey = GetNavigationKey<TViewModel>();
         return builder.CreateTab(navigationKey);
     }
 
     public static ITabbedSegmentBuilder SelectTab<TViewModel>(this ITabbedSegmentBuilder builder)
-        where TViewModel : class, INotifyPropertyChanged
     {
         var navigationKey = GetNavigationKey<TViewModel>();
         return builder.SelectedTab(navigationKey);

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -1,4 +1,3 @@
-using Prism.Behaviors;
 using Prism.Common;
 using Prism.Events;
 using Prism.Ioc;
@@ -11,6 +10,7 @@ namespace Prism.Navigation;
 /// </summary>
 public class PageNavigationService : INavigationService, IPageAware
 {
+    private static readonly SemaphoreSlim _semaphore = new (1, 1);
     internal const string RemovePageRelativePath = "../";
     internal const string RemovePageInstruction = "__RemovePage/";
     internal const string RemovePageSegment = "__RemovePage";
@@ -64,6 +64,7 @@ public class PageNavigationService : INavigationService, IPageAware
     /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
     public virtual async Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
     {
+        await _semaphore.WaitAsync();
         Page page = null;
         try
         {
@@ -105,6 +106,7 @@ public class PageNavigationService : INavigationService, IPageAware
         finally
         {
             NavigationSource = PageNavigationSource.Device;
+            _semaphore.Release();
         }
 
         return Notify(NavigationRequestType.GoBack, parameters, GetGoBackException(page, GetPageFromWindow()));
@@ -158,6 +160,7 @@ public class PageNavigationService : INavigationService, IPageAware
     /// <remarks>Only works when called from a View within a NavigationPage</remarks>
     public virtual async Task<INavigationResult> GoBackToRootAsync(INavigationParameters parameters)
     {
+        await _semaphore.WaitAsync();
         try
         {
             if (parameters is null)
@@ -199,6 +202,7 @@ public class PageNavigationService : INavigationService, IPageAware
         finally
         {
             NavigationSource = PageNavigationSource.Device;
+            _semaphore.Release();
         }
     }
 
@@ -213,6 +217,7 @@ public class PageNavigationService : INavigationService, IPageAware
     /// </example>
     public virtual async Task<INavigationResult> NavigateAsync(Uri uri, INavigationParameters parameters)
     {
+        await _semaphore.WaitAsync();
         try
         {
             if (parameters is null)
@@ -240,6 +245,7 @@ public class PageNavigationService : INavigationService, IPageAware
         finally
         {
             NavigationSource = PageNavigationSource.Device;
+            _semaphore.Release();
         }
     }
 


### PR DESCRIPTION
# Description

There are scenarios where you may Navigate say to a Splash Page which does some logic as part of the initialization. This may then result in a 2nd Navigation Call before the initial navigation has completed. The result is that while the Navigation Service reports a Successful Navigation, the UI is not updated. This introduces a static SemaphoreSlim which forces all Navigation calls to wait until any currently executing call has completed. This fixes the issue for scenarios as outlined above, ensuring that navigation completes and the Window is updated to reflect the correct Navigation Stack.