### PR TITLE
generate Rx package on build

### DIFF
--- a/src/Prism.Maui.Rx/Prism.Maui.Rx.csproj
+++ b/src/Prism.Maui.Rx/Prism.Maui.Rx.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>true</ImplicitUsings>
     <Description>Prism.Maui.Rx is a support package for .NET MAUI developers. This package provides some helpers to access an IObservable for globally handling Navigation Request Results.</Description>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Adds GeneratePackageOnBuild attribute so that we generate the Prism.Maui.Rx package.

Makes the `IObservable<NavigationRequestContext>` available on the PrismAppBuilder