### PR TITLE
Add TargetAware Xaml Extension

### DIFF
--- a/sample/PrismMauiDemo/Views/MainPage.xaml
+++ b/sample/PrismMauiDemo/Views/MainPage.xaml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <FlyoutPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             xmlns:prism="http://prismlibrary.com"
-             x:Class="PrismMauiDemo.Views.MainPage"
-             Title="MainPage"
-             BackgroundColor="White">
+            x:Class="PrismMauiDemo.Views.MainPage"
+            Title="MainPage"
+            BackgroundColor="White">
   <FlyoutPage.Flyout>
     <ContentPage Title="Menu">
       <StackLayout Margin="20">

--- a/src/Prism.Maui/Behaviors/ElementParentedCallbackBehavior.cs
+++ b/src/Prism.Maui/Behaviors/ElementParentedCallbackBehavior.cs
@@ -4,11 +4,11 @@ using Prism.Navigation.Xaml;
 
 namespace Prism.Behaviors;
 
-internal class DelayedRegionCreationCallbackBehavior : Behavior<VisualElement>
+internal class ElementParentedCallbackBehavior : Behavior<VisualElement>
 {
     private Action _callback { get; }
 
-    public DelayedRegionCreationCallbackBehavior(Action callback)
+    public ElementParentedCallbackBehavior(Action callback)
     {
         _callback = callback;
     }
@@ -27,12 +27,18 @@ internal class DelayedRegionCreationCallbackBehavior : Behavior<VisualElement>
 
     private void OnParentChanged(object sender, EventArgs e)
     {
-        var parent = (sender as VisualElement).Parent;
-        Console.WriteLine($"Parent: {parent.GetType().Name}");
         if (sender is not VisualElement view || view.Parent is null)
             return;
         else if (view.TryGetParentPage(out var page))
+        {
+            if(page.GetContainerProvider() is null)
+            {
+                view.ParentChanged -= OnParentChanged;
+                _callback();
+                return;
+            }
             page.PropertyChanged += PagePropertyChanged;
+        }
         else
             view.Parent.ParentChanged += OnParentChanged;
 

--- a/src/Prism.Maui/Navigation/Xaml/Navigation.cs
+++ b/src/Prism.Maui/Navigation/Xaml/Navigation.cs
@@ -107,8 +107,13 @@ public static class Navigation
             return null;
 
         var container = bindable.GetValue(NavigationScopeProperty) as IContainerProvider;
-        if (container is not null || bindable is Page)
+        if (container is not null)
             return container;
+        else if(bindable is Page page)
+        {
+            if (page.Parent is FlyoutPage flyout && flyout.Flyout == page)
+                return flyout.GetContainerProvider();
+        }
         else if (bindable is Element element && element.Parent is not null)
             return GetContainerProvider(element.Parent);
 

--- a/src/Prism.Maui/Properties/AssemblyInfo.cs
+++ b/src/Prism.Maui/Properties/AssemblyInfo.cs
@@ -9,4 +9,4 @@
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Navigation.Xaml")]
 [assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Regions.Xaml")]
 //[assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Services.Dialogs.Xaml")]
-//[assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Xaml")]
+[assembly: XmlnsDefinition("http://prismlibrary.com", "Prism.Xaml")]

--- a/src/Prism.Maui/Regions/Behaviors/DelayedRegionCreationBehavior.cs
+++ b/src/Prism.Maui/Regions/Behaviors/DelayedRegionCreationBehavior.cs
@@ -69,7 +69,7 @@ public class DelayedRegionCreationBehavior
     public void Attach()
     {
         RegionManagerAccessor.UpdatingRegions += OnUpdatingRegions;
-        TargetElement.Behaviors.Add(new DelayedRegionCreationCallbackBehavior(TryCreateRegion));
+        TargetElement.Behaviors.Add(new ElementParentedCallbackBehavior(TryCreateRegion));
     }
 
     /// <summary>

--- a/src/Prism.Maui/Xaml/TargetAwareExtensionBase.cs
+++ b/src/Prism.Maui/Xaml/TargetAwareExtensionBase.cs
@@ -1,0 +1,79 @@
+﻿using System.Windows.Input;
+using Prism.Behaviors;
+using Prism.Extensions;
+using Prism.Ioc;
+using Prism.Navigation.Xaml;
+using Prism.Properties;
+
+namespace Prism.Xaml;
+
+public abstract class TargetAwareExtensionBase<T> : BindableObject, IMarkupExtension<T>
+{
+    private Page _page;
+    public Page Page
+    {
+        get => _page;
+        set
+        {
+            OnPropertyChanging(nameof(Page));
+            _page = value;
+            OnPropertyChanged(nameof(Page));
+        }
+    }
+
+    private VisualElement _targetElement;
+    public VisualElement TargetElement
+    {
+        get => _targetElement;
+        set
+        {
+            OnPropertyChanging(nameof(TargetElement));
+            _targetElement = value;
+            OnPropertyChanged(nameof(TargetElement));
+        }
+    }
+
+    protected IContainerProvider Container => TargetElement.GetContainerProvider();
+
+    /// <summary>
+    /// Sets the Target BindingContext strategy
+    /// </summary>
+    public TargetBindingContext TargetBindingContext { get; set; }
+
+    T IMarkupExtension<T>.ProvideValue(IServiceProvider serviceProvider)
+    {
+        var valueTargetProvider = serviceProvider.GetService<IProvideValueTarget>();
+
+        if (valueTargetProvider == null)
+            throw new ArgumentException(Resources.ServiceProviderDidNotHaveIProvideValueTarget);
+
+        TargetElement = valueTargetProvider.TargetObject as VisualElement;
+
+        //this is handling the scenario of the extension being used within the EventToCommandBehavior
+        if (TargetElement is null && valueTargetProvider.TargetObject is BehaviorBase<BindableObject> behavior)
+            TargetElement = behavior.AssociatedObject as VisualElement;
+
+        if (TargetElement is null)
+            throw new Exception($"{valueTargetProvider.TargetObject} is not supported");
+
+        var path = TargetBindingContext switch
+        {
+            TargetBindingContext.Element => "TargetElement.BindingContext",
+            _ => "Page.BindingContext"
+        };
+
+        SetBinding(BindingContextProperty, new Binding(path, BindingMode.OneWay, source: this));
+
+        if (TargetElement.TryGetParentPage(out var page))
+            Page = page;
+        else
+            TargetElement.Behaviors.Add(new ElementParentedCallbackBehavior(() => Page = TargetElement.GetParentPage()));
+
+        return ProvideValue(serviceProvider);
+    }
+
+    object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) => 
+        ((IMarkupExtension<T>)this).ProvideValue(serviceProvider);
+
+    protected abstract T ProvideValue(IServiceProvider serviceProvider);
+}

--- a/src/Prism.Maui/Xaml/TargetBindingContext.cs
+++ b/src/Prism.Maui/Xaml/TargetBindingContext.cs
@@ -1,0 +1,17 @@
+﻿namespace Prism.Xaml;
+
+/// <summary>
+/// Target BindingContext behavior for the <see cref="TargetAwareExtensionBase{T}" />
+/// </summary>
+public enum TargetBindingContext
+{
+    /// <summary>
+    /// Use the Target Element's Binding Context
+    /// </summary>
+    Element = 0,
+
+    /// <summary>
+    /// Use the Parent Page's Binding Context (usually the ViewModel)
+    /// </summary>
+    Page = 1
+}


### PR DESCRIPTION
# Description

Add TargetAware base XAML Extension. This Exposes properties for the TargetElement, ParentPage & Scoped IContainerProvider from the Page. There is also a TargetBindingContext to control whether the Extension's BindingContext is shared with the Element or Page.