### PR TITLE
Encapsulate PrismAppBuilder

### DIFF
--- a/sample/PrismMauiDemo/MauiProgram.cs
+++ b/sample/PrismMauiDemo/MauiProgram.cs
@@ -11,36 +11,37 @@ public static class MauiProgram
     public static MauiApp CreateMauiApp()
     {
         return MauiApp.CreateBuilder()
-            .UsePrismApp<App>()
-            .ConfigureModuleCatalog(moduleCatalog =>
-            {
-                moduleCatalog.AddModule<MauiAppModule>();
-                moduleCatalog.AddModule<MauiTestRegionsModule>();
-            })
-            .RegisterTypes(containerRegistry =>
-            {
-                containerRegistry.RegisterGlobalNavigationObserver();
-                containerRegistry.RegisterForNavigation<MainPage>();
-                containerRegistry.RegisterForNavigation<RootPage>();
-                containerRegistry.RegisterForNavigation<SamplePage>();
-                containerRegistry.RegisterForNavigation<SplashPage>();
-            })
-            .AddGlobalNavigationObserver(context => context.Subscribe(x =>
-            {
-                if (x.Type == NavigationRequestType.Navigate)
-                    Console.WriteLine($"Navigation: {x.Type} - {x.Uri}");
-                else
-                    Console.WriteLine($"Navigation: {x.Type}");
+            .UsePrismApp<App>(prism => 
+                prism.ConfigureModuleCatalog(moduleCatalog =>
+                {
+                    moduleCatalog.AddModule<MauiAppModule>();
+                    moduleCatalog.AddModule<MauiTestRegionsModule>();
+                })
+                .RegisterTypes(containerRegistry =>
+                {
+                    containerRegistry.RegisterGlobalNavigationObserver();
+                    containerRegistry.RegisterForNavigation<MainPage>();
+                    containerRegistry.RegisterForNavigation<RootPage>();
+                    containerRegistry.RegisterForNavigation<SamplePage>();
+                    containerRegistry.RegisterForNavigation<SplashPage>();
+                })
+                .AddGlobalNavigationObserver(context => context.Subscribe(x =>
+                {
+                    if (x.Type == NavigationRequestType.Navigate)
+                        Console.WriteLine($"Navigation: {x.Type} - {x.Uri}");
+                    else
+                        Console.WriteLine($"Navigation: {x.Type}");
 
-                var status = x.Cancelled ? "Cancelled" : x.Result.Success ? "Success" : "Failed";
-                Console.WriteLine($"Result: {status}");
+                    var status = x.Cancelled ? "Cancelled" : x.Result.Success ? "Success" : "Failed";
+                    Console.WriteLine($"Result: {status}");
 
-                if (status == "Failed" && !string.IsNullOrEmpty(x.Result?.Exception?.Message))
-                    Console.Error.WriteLine(x.Result.Exception.Message);
-            }))
-            .OnAppStart(navigationService => navigationService.CreateBuilder()
-                .AddNavigationSegment<SplashPageViewModel>()
-                .Navigate(HandleNavigationError))
+                    if (status == "Failed" && !string.IsNullOrEmpty(x.Result?.Exception?.Message))
+                        Console.Error.WriteLine(x.Result.Exception.Message);
+                }))
+                .OnAppStart(navigationService => navigationService.CreateBuilder()
+                    .AddNavigationSegment<SplashPageViewModel>()
+                    .Navigate(HandleNavigationError))
+            )
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/src/Prism.DryIoc.Maui/PrismAppExtensions.cs
+++ b/src/Prism.DryIoc.Maui/PrismAppExtensions.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Maui;
 /// </summary>
 public static class PrismAppExtensions
 {
-    public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder)
+    public static MauiAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, Action<PrismAppBuilder> configurePrism)
         where TApp : Application
     {
-        return builder.UsePrismApp<TApp>(new DryIocContainerExtension());
+        return builder.UsePrismApp<TApp>(new DryIocContainerExtension(), configurePrism);
     }
 
-    public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, Rules rules)
+    public static MauiAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, Rules rules, Action<PrismAppBuilder> configurePrism)
         where TApp : Application
     {
         rules = rules.WithTrackingDisposableTransients()
             .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
             .WithFactorySelector(Rules.SelectLastRegisteredFactory());
-        return builder.UsePrismApp<TApp>(new DryIocContainerExtension(rules));
+        return builder.UsePrismApp<TApp>(new DryIocContainerExtension(rules), configurePrism);
     }
 }

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -126,10 +126,10 @@ public abstract class PrismAppBuilder
             _onAppStarted(_container, _container.Resolve<INavigationService>());
     }
 
-    public MauiAppBuilder OnAppStart(Action<IContainerProvider, INavigationService> onAppStarted)
+    public PrismAppBuilder OnAppStart(Action<IContainerProvider, INavigationService> onAppStarted)
     {
         _onAppStarted = onAppStarted;
-        return MauiBuilder;
+        return this;
     }
 
     /// <summary>

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -8,7 +8,6 @@ using Prism.Modularity;
 using Prism.Mvvm;
 using Prism.Navigation;
 using Prism.Navigation.Xaml;
-using Prism.Regions;
 using Prism.Regions.Adapters;
 using Prism.Regions.Behaviors;
 using Prism.Services;
@@ -18,7 +17,7 @@ namespace Prism;
 public sealed class PrismAppBuilder<TApp> : PrismAppBuilder
     where TApp : Application
 {
-    public PrismAppBuilder(IContainerExtension containerExtension, MauiAppBuilder builder)
+    internal PrismAppBuilder(IContainerExtension containerExtension, MauiAppBuilder builder)
         : base(containerExtension, builder)
     {
         builder.UseMauiApp<TApp>();
@@ -34,7 +33,7 @@ public abstract class PrismAppBuilder
     private Action<RegionAdapterMappings> _configureAdapters;
     private Action<IRegionBehaviorFactory> _configureBehaviors;
 
-    protected PrismAppBuilder(IContainerExtension containerExtension, MauiAppBuilder builder)
+    internal PrismAppBuilder(IContainerExtension containerExtension, MauiAppBuilder builder)
     {
         if (containerExtension is null)
             throw new ArgumentNullException(nameof(containerExtension));

--- a/src/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -9,10 +9,12 @@ public static class PrismAppBuilderExtensions
 {
     private static bool s_didRegisterModules = false;
 
-    public static PrismAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, IContainerExtension containerExtension)
+    public static MauiAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, IContainerExtension containerExtension, Action<PrismAppBuilder> configurePrism)
         where TApp : Application
     {
-        return new PrismAppBuilder<TApp>(containerExtension, builder);
+        var prismBuilder = new PrismAppBuilder<TApp>(containerExtension, builder);
+        configurePrism(prismBuilder);
+        return builder;
     }
 
     public static PrismAppBuilder OnInitialized(this PrismAppBuilder builder, Action action)

--- a/src/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -44,16 +44,16 @@ public static class PrismAppBuilderExtensions
         });
     }
 
-    public static MauiAppBuilder OnAppStart(this PrismAppBuilder builder, string uri) =>
+    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, string uri) =>
         builder.OnAppStart(navigation => navigation.NavigateAsync(uri));
 
-    public static MauiAppBuilder OnAppStart(this PrismAppBuilder builder, Action<INavigationService> onAppStarted) =>
+    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Action<INavigationService> onAppStarted) =>
         builder.OnAppStart((_, n) => onAppStarted(n));
 
-    public static MauiAppBuilder OnAppStart(this PrismAppBuilder builder, Func<IContainerProvider, INavigationService, Task> onAppStarted) =>
+    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<IContainerProvider, INavigationService, Task> onAppStarted) =>
         builder.OnAppStart(async (c, n) => await onAppStarted(c, n));
 
-    public static MauiAppBuilder OnAppStart(this PrismAppBuilder builder, Func<INavigationService, Task> onAppStarted) =>
+    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Func<INavigationService, Task> onAppStarted) =>
         builder.OnAppStart(async (_, n) => await onAppStarted(n));
 
     public static PrismAppBuilder ConfigureServices(this PrismAppBuilder builder, Action<IServiceCollection> configureServices)

--- a/src/Prism.Maui/Regions/Xaml/RegionManager.cs
+++ b/src/Prism.Maui/Regions/Xaml/RegionManager.cs
@@ -95,7 +95,7 @@ public static class RegionManager
     {
         if (view is null) throw new ArgumentNullException(nameof(view));
 
-        if (!(view.GetValue(ObservableRegionProperty) is ObservableObject<IRegion> regionWrapper))
+        if (view.GetValue(ObservableRegionProperty) is not ObservableObject<IRegion> regionWrapper)
         {
             regionWrapper = new ObservableObject<IRegion>();
             view.SetValue(ObservableRegionProperty, regionWrapper);
@@ -104,7 +104,7 @@ public static class RegionManager
         return regionWrapper;
     }
 
-    private static async void OnSetRegionNameCallback(BindableObject bindable, object oldValue, object newValue)
+    private static void OnSetRegionNameCallback(BindableObject bindable, object oldValue, object newValue)
     {
         if (DesignMode.IsDesignModeEnabled || newValue is null || bindable is not VisualElement view)
             return;

--- a/tests/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -11,8 +11,7 @@ public class NavigationTests
     [InlineData("MockHome/NavigationPage/MockViewA")]
     public void PagesInjectScopedInstanceOfIPageAccessor(string uri)
     {
-        var mauiApp = CreateBuilder()
-            .OnAppStart(navigation => navigation.NavigateAsync(uri))
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart(navigation => navigation.NavigateAsync(uri)))
             .Build();
         var app = mauiApp.Services.GetRequiredService<IApplication>() as Application;
         var window = app!.Windows.First();
@@ -54,14 +53,17 @@ public class NavigationTests
         Assert.Same(page, viewModel!.Page);
     }
 
-    private PrismAppBuilder CreateBuilder() =>
+    private MauiAppBuilder CreateBuilder(Action<PrismAppBuilder> configurePrism) =>
         MauiApp.CreateBuilder()
-            .UsePrismApp<Application>()
-            .RegisterTypes(container =>
+            .UsePrismApp<Application>(prism =>
             {
-                container.RegisterForNavigation<MockHome, MockHomeViewModel>()
-                    .RegisterForNavigation<MockViewA, MockViewAViewModel>()
-                    .RegisterForNavigation<MockViewB, MockViewBViewModel>()
-                    .RegisterForNavigation<MockViewC, MockViewCViewModel>();
+                prism.RegisterTypes(container =>
+                {
+                    container.RegisterForNavigation<MockHome, MockHomeViewModel>()
+                        .RegisterForNavigation<MockViewA, MockViewAViewModel>()
+                        .RegisterForNavigation<MockViewB, MockViewBViewModel>()
+                        .RegisterForNavigation<MockViewC, MockViewCViewModel>();
+                });
+                configurePrism(prism);
             });
 }

--- a/tests/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
@@ -10,13 +10,13 @@ public class RegionFixture
     public void ContentRegion_CreatedBy_RequestNavigate()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>()
-            .RegisterTypes(container =>
-            {
-                container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
-                container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
-            })
-            .OnAppStart("MockContentRegionPage")
+            .UsePrismApp<Application>(prism =>
+                prism.RegisterTypes(container =>
+                {
+                    container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
+                    container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
+                })
+                .OnAppStart("MockContentRegionPage"))
             .Build();
 
         var app = mauiApp.Services.GetRequiredService<IApplication>() as Application;
@@ -36,18 +36,18 @@ public class RegionFixture
     public void FrameRegion_CreatedBy_RegisterViewWithRegion()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>()
-            .RegisterTypes(container =>
-            {
-                container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
-                container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
-            })
-            .OnInitialized(container =>
-            {
-                var regionManager = container.Resolve<IRegionManager>();
-                regionManager.RegisterViewWithRegion("FrameRegion", "MockRegionViewA");
-            })
-            .OnAppStart("MockContentRegionPage")
+            .UsePrismApp<Application>(prism =>
+                prism.RegisterTypes(container =>
+                {
+                    container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
+                    container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
+                })
+                .OnInitialized(container =>
+                {
+                    var regionManager = container.Resolve<IRegionManager>();
+                    regionManager.RegisterViewWithRegion("FrameRegion", "MockRegionViewA");
+                })
+                .OnAppStart("MockContentRegionPage"))
             .Build();
 
         var app = mauiApp.Services.GetRequiredService<IApplication>() as Application;
@@ -67,18 +67,18 @@ public class RegionFixture
     public void RegionsShareContainer_WithPage()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>()
-            .RegisterTypes(container =>
-            {
-                container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
-                container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
-            })
-            .OnInitialized(container =>
-            {
-                var regionManager = container.Resolve<IRegionManager>();
-                regionManager.RegisterViewWithRegion("FrameRegion", "MockRegionViewA");
-            })
-            .OnAppStart("MockContentRegionPage")
+            .UsePrismApp<Application>(prism =>
+                prism.RegisterTypes(container =>
+                {
+                    container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
+                    container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
+                })
+                .OnInitialized(container =>
+                {
+                    var regionManager = container.Resolve<IRegionManager>();
+                    regionManager.RegisterViewWithRegion("FrameRegion", "MockRegionViewA");
+                })
+                .OnAppStart("MockContentRegionPage"))
             .Build();
 
         var app = mauiApp.Services.GetRequiredService<IApplication>() as Application;
@@ -104,13 +104,13 @@ public class RegionFixture
     {
         // This validates that the NavigationService is using the correct Page to navigate from
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>()
-            .RegisterTypes(container =>
-            {
-                container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
-                container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
-            })
-            .OnAppStart("MockContentRegionPage")
+            .UsePrismApp<Application>(prism =>
+                prism.RegisterTypes(container =>
+                {
+                    container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
+                    container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
+                })
+                .OnAppStart("MockContentRegionPage"))
             .Build();
 
         var regionManager = mauiApp.Services.GetRequiredService<IRegionManager>();
@@ -128,12 +128,12 @@ public class RegionFixture
     public void RegionManager_HasTwoRegions()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>()
-            .RegisterTypes(container =>
-            {
-                container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
-            })
-            .OnAppStart("MockContentRegionPage")
+            .UsePrismApp<Application>(prism => 
+                prism.RegisterTypes(container =>
+                {
+                    container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
+                })
+                .OnAppStart("MockContentRegionPage"))
             .Build();
 
         var regionManager = mauiApp.Services.GetRequiredService<IRegionManager>();


### PR DESCRIPTION
# Description

Rather than hijacking the entire MauiAppBuilder, we now provide a delegate to encapsulate the PrismAppBuilder. OnAppStart has also been updated so that it returns the PrismAppBuilder and can be used at any point of your configuration.

- closes #50